### PR TITLE
Build core packages before running the dev environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:packages": "turbo run build --filter=./packages/*",
     "test": "turbo run test",
     "lint": "eslint .",
-    "dev": "turbo run dev --parallel",
+    "dev": "npm run build:packages && turbo run dev --parallel",
     "prepare": "husky install",
     "typedoc": "typedoc",
     "typedoc:watch": "typedoc --watch",


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Right now we get an error, if we use `npm run dev` before building the core packages. This change makes sure the core packages are built so that it's only necessary to run `npm install` and `npm run dev` after that.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
- Clone this headless project;
- Install the packages by running `npm install` from the root folder;
- Run `npm run dev` after that and make sure you can access the app from `http://localhost:3000` without any errors.
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

