### PR TITLE
fix: some params are not taken into account by buildEndpointUrl

### DIFF
--- a/.changeset/famous-pugs-kiss.md
+++ b/.changeset/famous-pugs-kiss.md
@@ -1,0 +1,6 @@
+---
+"@10up/headless-core": patch
+"@10up/headless-next": patch
+---
+
+Fix [#210](https://github.com/10up/headless/issues/210) - Some params are not taken into account by buildEndpointUrl

--- a/packages/core/src/react/hooks/__tests__/useFetchPost.tsx
+++ b/packages/core/src/react/hooks/__tests__/useFetchPost.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
 import { SettingsProvider } from '../../provider';
 import { useFetchPost } from '../useFetchPost';
 
@@ -45,6 +46,7 @@ describe('useFetchPost', () => {
 		});
 
 		await waitForNextUpdate();
+		expect(result.current.data?.post.id).toBe(64);
 		expect(result.current.data?.post.slug).toBe('ipsum-repudiandae-est-nam');
 	});
 

--- a/packages/core/src/react/hooks/__tests__/useFetchPosts.tsx
+++ b/packages/core/src/react/hooks/__tests__/useFetchPosts.tsx
@@ -66,8 +66,6 @@ describe('useFetchPosts', () => {
 				useFetchPosts({
 					category: 'الأخبار-المالية',
 					per_page: 1,
-					// TODO: Fix this. The endpoint URL is not properly created when querying by category.
-					dummy: 'test',
 				}),
 			{
 				wrapper,

--- a/packages/core/src/react/hooks/useFetch.ts
+++ b/packages/core/src/react/hooks/useFetch.ts
@@ -33,9 +33,10 @@ export function useFetch<E, Params extends EndpointParams, R = E>(
 
 	const urlParams = fetchStrategy.getParamsFromURL(path, params);
 	const finalParams = { ...urlParams, ...params };
+
 	const result = useSWR<FetchResponse<R>>(
-		fetchStrategy.buildEndpointURL(finalParams),
-		(url: string) => fetchStrategy.fetcher(url, finalParams),
+		{ url: fetchStrategy.getEndpoint(), args: finalParams },
+		({ args }) => fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(args), finalParams),
 		options,
 	);
 

--- a/packages/next/src/data/utils.ts
+++ b/packages/next/src/data/utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@10up/headless-core';
 import { getHeadlessConfig } from '@10up/headless-core/utils';
 import { GetServerSidePropsContext, GetServerSidePropsResult, GetStaticPropsContext } from 'next';
-
+import { unstable_serialize } from 'swr';
 import { PreviewData } from '../handlers/types';
 
 /**
@@ -91,7 +91,7 @@ export async function fetchHookData(
 	const finalParams = { _embed: true, ...urlParams, ...params };
 
 	// we don't want to include the preview params in the key
-	const endpointUrlForKey = fetchStrategy.buildEndpointURL(finalParams);
+	const key = { url: fetchStrategy.getEndpoint(), args: finalParams };
 
 	const isPreviewRequest =
 		typeof urlParams.slug === 'string' ? urlParams.slug.includes('-preview=true') : false;
@@ -110,7 +110,10 @@ export async function fetchHookData(
 
 	data.queriedObject = fetchStrategy.getQueriedObject(data, finalParams);
 
-	return { key: endpointUrlForKey, data: fetchStrategy.filterData(data, filterDataOptions) };
+	return {
+		key: unstable_serialize(key),
+		data: fetchStrategy.filterData(data, filterDataOptions),
+	};
 }
 
 type ExpectedHookStateResponse = {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
