### PR TITLE
Fix/fetch redirect

### DIFF
--- a/.changeset/lazy-seals-end.md
+++ b/.changeset/lazy-seals-end.md
@@ -1,0 +1,7 @@
+---
+"@10up/headless-core": patch
+---
+
+Improve redirect handling in `fetchRedirect`.
+
+It nows detects redirects that might cause infinite loop and ignore redirects for `wp-login.php`, `wp-register.php` and `wp-admin`.

--- a/packages/core/src/utils/__tests__/fetchRedirect.ts
+++ b/packages/core/src/utils/__tests__/fetchRedirect.ts
@@ -1,0 +1,27 @@
+import { fetchRedirect } from '../fetchRedirect';
+
+/**
+ * Redirects are mocked in msw
+ *
+ * see test/server-handlers.ts
+ */
+describe('fetchRedirect', () => {
+	it('catches redirect', async () => {
+		const result = await fetchRedirect('/redirect-test', 'http://example.com/');
+
+		expect(result.location).toEqual('/redirected-page');
+		expect(result.status).toEqual(301);
+	});
+
+	it('does not cause infinite loops', async () => {
+		const result = await fetchRedirect('/infinite-loop', 'http://example.com/');
+
+		expect(result.location).toBeNull();
+	});
+
+	it('ignore wp-login.php', async () => {
+		const result = await fetchRedirect('/rsa-blocked-page', 'http://example.com/');
+
+		expect(result.location).toBeNull();
+	});
+});

--- a/packages/core/test/mocks/redirect.ts
+++ b/packages/core/test/mocks/redirect.ts
@@ -1,0 +1,5 @@
+import { compose, context } from 'msw';
+
+export function redirect(destination, statusCode) {
+	return compose(context.status(statusCode), context.set('Location', destination));
+}

--- a/packages/core/test/server-handlers.ts
+++ b/packages/core/test/server-handlers.ts
@@ -1,4 +1,5 @@
 import { rest, DefaultRequestBody } from 'msw';
+import { redirect } from './mocks/redirect';
 import posts from './__fixtures__/posts/posts.json';
 
 interface TestEndpointResponse {
@@ -9,6 +10,18 @@ export const VALID_AUTH_TOKEN = 'this is a valid auth';
 export const DRAFT_POST_ID = 57;
 
 const handlers = [
+	rest.head('http://example.com/redirect-test', (req, res) => {
+		return res(redirect('http://example.com/redirected-page', 301));
+	}),
+
+	rest.head('http://example.com/infinite-loop', (req, res) => {
+		return res(redirect('http://example.com/infinite-loop', 301));
+	}),
+
+	rest.head('http://example.com/rsa-blocked-page', (req, res) => {
+		return res(redirect('http://example.com/wp-login.php', 301));
+	}),
+
 	rest.get<DefaultRequestBody, TestEndpointResponse>(/\/test-endpoint/, (req, res, ctx) => {
 		return res(ctx.json({ ok: true }));
 	}),


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #242 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
