### PR TITLE
fix: default params not taken into account

### DIFF
--- a/.changeset/red-cherries-reflect.md
+++ b/.changeset/red-cherries-reflect.md
@@ -1,0 +1,5 @@
+---
+"@10up/headless-core": patch
+---
+
+Fix: defaultParams were not being taken into account

--- a/packages/core/src/data/strategies/PostsArchiveFetchStrategy.ts
+++ b/packages/core/src/data/strategies/PostsArchiveFetchStrategy.ts
@@ -204,7 +204,7 @@ export class PostsArchiveFetchStrategy<
 	}
 
 	getDefaultParams(): Partial<P> {
-		return { _embed: true } as P;
+		return { _embed: true, ...super.getDefaultParams() } as P;
 	}
 
 	/**

--- a/packages/core/src/data/strategies/SinglePostFetchStrategy.ts
+++ b/packages/core/src/data/strategies/SinglePostFetchStrategy.ts
@@ -82,7 +82,7 @@ export class SinglePostFetchStrategy<
 	}
 
 	getDefaultParams(): Partial<P> {
-		return { _embed: true } as P;
+		return { _embed: true, ...super.getDefaultParams() } as P;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/core/src/data/strategies/TaxonomyTermsStrategy.ts
+++ b/packages/core/src/data/strategies/TaxonomyTermsStrategy.ts
@@ -107,7 +107,7 @@ export class TaxonomyTermsStrategy<
 	}
 
 	getDefaultParams(): Partial<P> {
-		return { _embed: true } as P;
+		return { _embed: true, ...super.getDefaultParams() } as P;
 	}
 
 	getParamsFromURL(

--- a/packages/core/src/data/strategies/__tests__/PostsArchiveFetchStrategy.ts
+++ b/packages/core/src/data/strategies/__tests__/PostsArchiveFetchStrategy.ts
@@ -464,4 +464,10 @@ describe('PostsArchiveFetchStrategy', () => {
 			{},
 		);
 	});
+
+	it('allows overriding default params', () => {
+		const defaultParams = { postType: 'book' };
+		const fetcher = new PostsArchiveFetchStrategy('http://sourceurl.com', defaultParams);
+		expect(fetcher.getDefaultParams()).toMatchObject(defaultParams);
+	});
 });

--- a/packages/core/src/data/strategies/__tests__/SinglePostFetchStrategy.ts
+++ b/packages/core/src/data/strategies/__tests__/SinglePostFetchStrategy.ts
@@ -444,4 +444,10 @@ describe('SinglePostFetchStrategy', () => {
 			result: post2,
 		});
 	});
+
+	it('allows overriding default params', () => {
+		const defaultParams = { postType: 'book' };
+		const fetcher = new SinglePostFetchStrategy('http://sourceurl.com', defaultParams);
+		expect(fetcher.getDefaultParams()).toMatchObject(defaultParams);
+	});
 });

--- a/packages/core/src/data/strategies/__tests__/TaxonomyTermsStrategy.ts
+++ b/packages/core/src/data/strategies/__tests__/TaxonomyTermsStrategy.ts
@@ -47,4 +47,10 @@ describe('TaxonomyTermsStrategy', () => {
 
 		expect(fetchStrategy.buildEndpointURL({ taxonomy: 'book' })).toBe('/wp-json/wp/v2/book');
 	});
+
+	it('allows overriding default params', () => {
+		const defaultParams = { taxonomy: 'genre' };
+		const fetcher = new TaxonomyTermsStrategy('http://sourceurl.com', defaultParams);
+		expect(fetcher.getDefaultParams()).toMatchObject(defaultParams);
+	});
 });


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
