### PR TITLE
fix: anchor tag attributes being stripped

### DIFF
--- a/.changeset/angry-roses-cry.md
+++ b/.changeset/angry-roses-cry.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": patch
+---
+
+Fix: anchor attributes being stripped by wpKsesPost

--- a/package-lock.json
+++ b/package-lock.json
@@ -23630,7 +23630,7 @@
         "path-to-regexp": "^6.2.0",
         "react-inspector": "^6.0.1",
         "swr": "^2.1.5",
-        "xss": "^1.0.11"
+        "xss": "^1.0.14"
       },
       "devDependencies": {
         "@testing-library/dom": "^8.19.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "path-to-regexp": "^6.2.0",
     "react-inspector": "^6.0.1",
     "swr": "^2.1.5",
-    "xss": "^1.0.11"
+    "xss": "^1.0.14"
   },
   "peerDependencies": {
     "react": ">= 17.0.2"

--- a/packages/core/src/dom/__tests__/wpKsesPost.ts
+++ b/packages/core/src/dom/__tests__/wpKsesPost.ts
@@ -126,4 +126,15 @@ describe('wp_kses_post', () => {
 		});
 		expect(onIgnoreTagAttr).toHaveBeenCalled();
 	});
+
+	// https://github.com/10up/headstartwp/issues/459
+	it('supports anchor tags target and rel', () => {
+		expect(
+			wpKsesPost(
+				'<a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">Hello World</a>',
+			),
+		).toBe(
+			'<a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">Hello World</a>',
+		);
+	});
 });

--- a/packages/core/src/dom/svg.ts
+++ b/packages/core/src/dom/svg.ts
@@ -187,19 +187,19 @@ const allowedSVGAttributes = [
 	'zoomandpan',
 ];
 
+export const svgHtmlAllowList: IWhiteList = {
+	a: allowedSVGAttributes,
+	font: allowedSVGAttributes,
+	image: allowedSVGAttributes,
+	style: allowedSVGAttributes,
+};
+
 /**
  * Default Allowed SVG elements and attributes
  *
  * @returns Array of allowed elements and attributes for SVG tags.
  */
 export const svgAllowList: IWhiteList = {
-	// HTML
-	a: allowedSVGAttributes,
-	font: allowedSVGAttributes,
-	image: allowedSVGAttributes,
-	style: allowedSVGAttributes,
-
-	// SVG
 	svg: allowedSVGAttributes,
 	altglyph: allowedSVGAttributes,
 	altglyphdef: allowedSVGAttributes,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
The issue was introduced after #393. The SVG HTML allow list was overriding the initial allow list for anchor tags. Additionally, there were some other attributes missing.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #459 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
