### PR TITLE
fix: cache burst for isr/ssg

### DIFF
--- a/.changeset/flat-badgers-perform.md
+++ b/.changeset/flat-badgers-perform.md
@@ -1,0 +1,6 @@
+---
+"@headstartwp/core": patch
+"@headstartwp/next": patch
+---
+
+Fix: fetch calls made under getStaticProps now always includes a timestamp in the query to ensure it always get latest content from the api

--- a/packages/core/src/data/api/fetch-utils.ts
+++ b/packages/core/src/data/api/fetch-utils.ts
@@ -37,7 +37,7 @@ export const apiPost = async (url: string, args: { [index: string]: any } = {}) 
  *
  * @param url The URL where to make the request to
  * @param args The arguments
- * @param withMinute Whether it should burst cahcing on every minute
+ * @param burstCache Whether it should burst cache
  *
  * @category Data Fetching
  *
@@ -46,7 +46,7 @@ export const apiPost = async (url: string, args: { [index: string]: any } = {}) 
 export const apiGet = async (
 	url: string,
 	args: { [index: string]: any } = {},
-	withMinute = false,
+	burstCache = false,
 ) => {
 	const headers = getAuthHeader();
 
@@ -54,24 +54,21 @@ export const apiGet = async (
 		args.headers = headers;
 	}
 
-	const coeff = 1000 * 60;
-	const date = new Date();
-	const currentMinute = new Date(Math.round(date.getTime() / coeff) * coeff).toISOString();
-
-	const queryArgs = withMinute
+	const queryArgs = burstCache
 		? {
-				// Busts cache every minute.
-				cacheTime: currentMinute,
+				cacheTime: new Date().getTime(),
 		  }
 		: {};
 
 	const config = getHeadlessConfig();
 
+	const fetchUrl = addQueryArgs(url, queryArgs);
+
 	if (config.debug?.requests) {
-		log(LOGTYPE.DEBUG, 'GET', url, args);
+		log(LOGTYPE.DEBUG, 'GET', fetchUrl, args);
 	}
 
-	const data = await fetch(addQueryArgs(url, queryArgs), args);
+	const data = await fetch(fetchUrl, args);
 
 	const receivedHeaders: { [index: string]: any } = [
 		...Array.from(data.headers.entries()),

--- a/packages/core/src/data/strategies/AbstractFetchStrategy.ts
+++ b/packages/core/src/data/strategies/AbstractFetchStrategy.ts
@@ -64,6 +64,11 @@ export interface FetchOptions {
 	 * The authentication token to use for the request.
 	 */
 	bearerToken?: string;
+
+	/**
+	 * Whether to burst cache by appending a timestamp to the query
+	 */
+	burstCache?: boolean;
 }
 
 export interface FilterDataOptions<T> {
@@ -231,13 +236,15 @@ export abstract class AbstractFetchStrategy<E, Params extends EndpointParams, R 
 		params: Partial<Params>,
 		options: Partial<FetchOptions> = {},
 	): Promise<FetchResponse<R>> {
+		const { burstCache = false } = options;
+
 		const args = {};
 		if (options.bearerToken) {
 			// @ts-expect-error
 			args.headers = { Authorization: `Bearer ${options.bearerToken}` };
 		}
 
-		const result = await apiGet(`${this.baseURL}${url}`, args);
+		const result = await apiGet(`${this.baseURL}${url}`, args, burstCache);
 		const { data } = result.json;
 
 		// if there's an error code and it's not a 4xx status code

--- a/packages/core/src/data/strategies/PostsArchiveFetchStrategy.ts
+++ b/packages/core/src/data/strategies/PostsArchiveFetchStrategy.ts
@@ -317,6 +317,7 @@ export class PostsArchiveFetchStrategy<
 	 * @param options FetchOptions
 	 */
 	async fetcher(url: string, params: Partial<P>, options: Partial<FetchOptions> = {}) {
+		const { burstCache = false } = options;
 		let finalUrl = url;
 		const settings = getSiteBySourceUrl(this.baseURL);
 
@@ -336,6 +337,8 @@ export class PostsArchiveFetchStrategy<
 				} else {
 					const terms = await apiGet(
 						`${this.baseURL}${taxonomy.endpoint}?slug=${params[paramSlug]}`,
+						{},
+						burstCache,
 					);
 
 					if (terms.json.length > 0) {
@@ -356,7 +359,11 @@ export class PostsArchiveFetchStrategy<
 		// 1 - params.author is a string
 		// 2 - We're not using the WP Plugin
 		if (params.author && typeof params.author === 'string' && !settings.useWordPressPlugin) {
-			const authors = await apiGet(`${this.baseURL}${authorsEndpoint}?slug=${params.author}`);
+			const authors = await apiGet(
+				`${this.baseURL}${authorsEndpoint}?slug=${params.author}`,
+				{},
+				burstCache,
+			);
 
 			if (authors.json.length > 0) {
 				finalUrl = addQueryArgs(finalUrl, {

--- a/packages/core/src/data/strategies/SearchFetchStrategy.ts
+++ b/packages/core/src/data/strategies/SearchFetchStrategy.ts
@@ -5,6 +5,7 @@ import { endpoints } from '../utils';
 import { apiGet } from '../api';
 import { addQueryArgs, getWPUrl } from '../../utils';
 import { PostEntity, QueriedObject } from '../types';
+import { FetchOptions } from './AbstractFetchStrategy';
 
 /**
  * The SearchFetchStrategy extends the {@link PostsArchiveFetchStrategy} and does not make use of the
@@ -40,8 +41,10 @@ export class SearchFetchStrategy<
 	 *
 	 * @param url The url to parse
 	 * @param params The params to build the endpoint with
+	 * @param options FetchOptions
 	 */
-	async fetcher(url: string, params: Partial<P>) {
+	async fetcher(url: string, params: Partial<P>, options: Partial<FetchOptions> = {}) {
+		const { burstCache = false } = options;
 		let seo_json: Record<string, any> = {};
 		let seo: string = '';
 
@@ -50,6 +53,8 @@ export class SearchFetchStrategy<
 				addQueryArgs(`${getWPUrl()}${endpoints.yoast}`, {
 					url: `${getWPUrl()}/?s=${params.search}`,
 				}),
+				{},
+				burstCache,
 			);
 
 			seo = result.json.html;
@@ -70,7 +75,7 @@ export class SearchFetchStrategy<
 			},
 		};
 
-		const response = await super.fetcher(url, params, { throwIfNotFound: false });
+		const response = await super.fetcher(url, params, { ...options, throwIfNotFound: false });
 
 		return {
 			...response,

--- a/packages/core/src/data/strategies/SinglePostFetchStrategy.ts
+++ b/packages/core/src/data/strategies/SinglePostFetchStrategy.ts
@@ -267,6 +267,8 @@ export class SinglePostFetchStrategy<
 	 * @param options FetchOptions
 	 */
 	async fetcher(url: string, params: P, options: Partial<FetchOptions> = {}) {
+		const { burstCache = false } = options;
+
 		if (params.authToken) {
 			options.bearerToken = params.authToken;
 		}
@@ -281,6 +283,7 @@ export class SinglePostFetchStrategy<
 							Authorization: `Bearer ${options.bearerToken}`,
 						},
 					},
+					burstCache,
 				);
 
 				if (Array.isArray(response.json) && response.json.length > 0) {

--- a/packages/core/src/data/strategies/__tests__/PostsArchiveFetchStrategy.ts
+++ b/packages/core/src/data/strategies/__tests__/PostsArchiveFetchStrategy.ts
@@ -248,40 +248,68 @@ describe('PostsArchiveFetchStrategy', () => {
 			1,
 			'/wp-json/wp/v2/posts?year=2021&month=10&day=30',
 			{},
+			false,
 		);
 
 		params = fetchStrategy.getParamsFromURL('/2021/');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
-		expect(apiGetMock).toHaveBeenNthCalledWith(2, '/wp-json/wp/v2/posts?year=2021', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(2, '/wp-json/wp/v2/posts?year=2021', {}, false);
 
 		params = fetchStrategy.getParamsFromURL('/author/author-test');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
 
-		expect(apiGetMock).toHaveBeenNthCalledWith(3, '/wp-json/wp/v2/users?slug=author-test');
-		expect(apiGetMock).toHaveBeenNthCalledWith(4, '/wp-json/wp/v2/posts?author=1', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			3,
+			'/wp-json/wp/v2/users?slug=author-test',
+			{},
+			false,
+		);
+		expect(apiGetMock).toHaveBeenNthCalledWith(4, '/wp-json/wp/v2/posts?author=1', {}, false);
 
 		params = fetchStrategy.getParamsFromURL('/category/category-test');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
 		expect(apiGetMock).toHaveBeenNthCalledWith(
 			5,
 			'/wp-json/wp/v2/categories?slug=category-test',
+			{},
+			false,
 		);
-		expect(apiGetMock).toHaveBeenNthCalledWith(6, '/wp-json/wp/v2/posts?categories=1', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			6,
+			'/wp-json/wp/v2/posts?categories=1',
+			{},
+			false,
+		);
 
 		params = fetchStrategy.getParamsFromURL('/tag/tag-test');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
-		expect(apiGetMock).toHaveBeenNthCalledWith(7, '/wp-json/wp/v2/tags?slug=tag-test');
-		expect(apiGetMock).toHaveBeenNthCalledWith(8, '/wp-json/wp/v2/posts?tags=1', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			7,
+			'/wp-json/wp/v2/tags?slug=tag-test',
+			{},
+			false,
+		);
+		expect(apiGetMock).toHaveBeenNthCalledWith(8, '/wp-json/wp/v2/posts?tags=1', {}, false);
 
 		params = fetchStrategy.getParamsFromURL('/genre/action');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
-		expect(apiGetMock).toHaveBeenNthCalledWith(9, '/wp-json/wp/v2/genre?slug=action');
-		expect(apiGetMock).toHaveBeenNthCalledWith(10, '/wp-json/wp/v2/posts?genre=1', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			9,
+			'/wp-json/wp/v2/genre?slug=action',
+			{},
+			false,
+		);
+		expect(apiGetMock).toHaveBeenNthCalledWith(10, '/wp-json/wp/v2/posts?genre=1', {}, false);
 
 		params = fetchStrategy.getParamsFromURL('/type/type-test');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
-		expect(apiGetMock).toHaveBeenNthCalledWith(11, '/wp-json/wp/v2/types?slug=type-test');
-		expect(apiGetMock).toHaveBeenNthCalledWith(12, '/wp-json/wp/v2/posts?type=1', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			11,
+			'/wp-json/wp/v2/types?slug=type-test',
+			{},
+			false,
+		);
+		expect(apiGetMock).toHaveBeenNthCalledWith(12, '/wp-json/wp/v2/posts?type=1', {}, false);
 
 		// with a custom post type
 		params = fetchStrategy.getParamsFromURL('/genre/action/page/2');
@@ -291,8 +319,18 @@ describe('PostsArchiveFetchStrategy', () => {
 			paramsWithPostType,
 		);
 
-		expect(apiGetMock).toHaveBeenNthCalledWith(13, '/wp-json/wp/v2/genre?slug=action');
-		expect(apiGetMock).toHaveBeenNthCalledWith(14, '/wp-json/wp/v2/book?page=2&genre=1', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			13,
+			'/wp-json/wp/v2/genre?slug=action',
+			{},
+			false,
+		);
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			14,
+			'/wp-json/wp/v2/book?page=2&genre=1',
+			{},
+			false,
+		);
 	});
 
 	it('throws exceptions when content is not found (without wordpress plugin)', async () => {
@@ -370,6 +408,7 @@ describe('PostsArchiveFetchStrategy', () => {
 			1,
 			'/wp-json/wp/v2/posts?author=author-test',
 			{},
+			false,
 		);
 
 		params = fetchStrategy.getParamsFromURL('/category/category-test');
@@ -378,19 +417,35 @@ describe('PostsArchiveFetchStrategy', () => {
 			2,
 			'/wp-json/wp/v2/posts?categories=category-test',
 			{},
+			false,
 		);
 
 		params = fetchStrategy.getParamsFromURL('/tag/tag-test');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
-		expect(apiGetMock).toHaveBeenNthCalledWith(3, '/wp-json/wp/v2/posts?tags=tag-test', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			3,
+			'/wp-json/wp/v2/posts?tags=tag-test',
+			{},
+			false,
+		);
 
 		params = fetchStrategy.getParamsFromURL('/genre/action');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
-		expect(apiGetMock).toHaveBeenNthCalledWith(4, '/wp-json/wp/v2/posts?genre=action', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			4,
+			'/wp-json/wp/v2/posts?genre=action',
+			{},
+			false,
+		);
 
 		params = fetchStrategy.getParamsFromURL('/type/type-test');
 		await fetchStrategy.fetcher(fetchStrategy.buildEndpointURL(params), params);
-		expect(apiGetMock).toHaveBeenNthCalledWith(5, '/wp-json/wp/v2/posts?type=type-test', {});
+		expect(apiGetMock).toHaveBeenNthCalledWith(
+			5,
+			'/wp-json/wp/v2/posts?type=type-test',
+			{},
+			false,
+		);
 
 		// with a custom post type
 		params = fetchStrategy.getParamsFromURL('/genre/action/page/2');
@@ -404,6 +459,7 @@ describe('PostsArchiveFetchStrategy', () => {
 			6,
 			'/wp-json/wp/v2/book?page=2&genre=action',
 			{},
+			false,
 		);
 	});
 
@@ -429,6 +485,7 @@ describe('PostsArchiveFetchStrategy', () => {
 			1,
 			'/wp-json/wp/v2/posts?genre-rest-param=genre-name',
 			{},
+			false,
 		);
 
 		params = fetchStrategy.getParamsFromURL('/genre-name/page/2', { taxonomy: 'genre' });
@@ -437,6 +494,7 @@ describe('PostsArchiveFetchStrategy', () => {
 			2,
 			'/wp-json/wp/v2/posts?page=2&genre-rest-param=genre-name',
 			{},
+			false,
 		);
 	});
 

--- a/packages/next/src/data/server/fetchHookData.ts
+++ b/packages/next/src/data/server/fetchHookData.ts
@@ -127,7 +127,12 @@ export async function fetchHookData<T = unknown, P extends EndpointParams = Endp
 	const data = await fetchStrategy.fetcher(
 		fetchStrategy.buildEndpointURL(finalParams),
 		finalParams,
-		options.fetchStrategyOptions,
+		{
+			// burst cache to skip REST API cache when the request is being made under getStaticProps
+			// if .req is not avaliable then this is a GetStaticPropsContext
+			burstCache: typeof (ctx as GetServerSidePropsContext).req === 'undefined',
+			...options.fetchStrategyOptions,
+		},
 	);
 
 	if (debug?.devMode) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
