### PR TITLE
fix(plugin.php): updated the Plugin URI to point to the plugin repo

### DIFF
--- a/wp/headless-wp/plugin.php
+++ b/wp/headless-wp/plugin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: HeadstartWP
- * Plugin URI:  false
+ * Plugin URI:  https://github.com/10up/headstartwp-plugin
  * Description: Adds functionality to the WordPress admin and REST API for 10up's headless framework.
  * Version: 1.0.6
  * Author:      10up


### PR DESCRIPTION
### Description of the Change

Updated the Plugin URI to point to the plugin repo

Closes #519 

### How to test the Change
1. Go to the plugins page
2. Click the Visit plugin page lint

### Changelog Entry
> Fixed - Fixed the 404 on the Vist plugin link


### Credits
Props @bmarshall511 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
