### PR TITLE
Documentation update for the WP plugin related to the install directory & name prop

### DIFF
--- a/docs/documentation/01-Getting Started/wordpress-plugin.md
+++ b/docs/documentation/01-Getting Started/wordpress-plugin.md
@@ -13,17 +13,21 @@ Make sure to set up the path for installing this as a WordPress Plugin:
 
 ```json
 {
-  "name": "your-project-name",
-  "require": {
-    "headstartwp/headstartwp": "^1.0.0",
-  },
-  "extra": {
-    "installer-paths": {
-      "plugins/{$name}/": [
-        "type:wordpress-plugin"
-      ]
-    }
-  }
+	"name": "your-vendor-name/your-project-name",
+	"require": {
+		"composer/installers": "^1.0",
+		"headstartwp/headstartwp": "^1.0.0"
+	},
+	"extra": {
+		"installer-paths": {
+			"plugins/{$name}/": ["type:wordpress-plugin"]
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
### Description of the Change

Updated the `wordpress-plugin.md` to make it clear what needs to be updated to avoid the plugin being installed in the `vendor` directory and prevent the `name` prop error related to missing a vendor prefix.

Closes #521 

### How to test the Change
1. On a fresh WP install, in terminal, navigate to the `wp-content` directory
2. Run `composer require headstartwp/headstartwp`
3. Update the `composer.json` file as directed in the updated `wordpress-plugin.md` in this PR
4. Run `composer update` then `composer install`

### Changelog Entry

> Fixed - Documentation update for the WP plugin related to the install directory & name prop

### Credits

Props @bmarshall511 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
