### PR TITLE
feat(revalidate): implements post_type archive revalidate

### DIFF
--- a/packages/next/src/handlers/revalidateHandler/index.ts
+++ b/packages/next/src/handlers/revalidateHandler/index.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { revalidatePost } from './revalidatePost';
+import { revalidateArchive } from './revalidateArchive';
 import { revalidateTerms } from './revalidateTerms';
 import { ERROR_MESSAGE } from './constants';
 
@@ -29,7 +30,7 @@ import { ERROR_MESSAGE } from './constants';
  * @category API handlers
  */
 export async function revalidateHandler(req: NextApiRequest, res: NextApiResponse) {
-	const { post_id, path, terms_ids, paths, total_pages, token } = req.query;
+	const { post_id, post_type, path, terms_ids, paths, total_pages, token } = req.query;
 
 	if (req.method !== 'GET') {
 		return res.status(401).json({ message: ERROR_MESSAGE.INVALID_METHOD });
@@ -37,6 +38,10 @@ export async function revalidateHandler(req: NextApiRequest, res: NextApiRespons
 
 	if (post_id && path && token) {
 		return revalidatePost(req, res);
+	}
+
+	if (post_type && path && total_pages && token) {
+		return revalidateArchive(req, res);
 	}
 
 	if (terms_ids && paths && total_pages && token) {

--- a/packages/next/src/handlers/revalidateHandler/revalidateArchive.ts
+++ b/packages/next/src/handlers/revalidateHandler/revalidateArchive.ts
@@ -1,0 +1,104 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getHeadlessConfig, getSiteByHost, VerifyTokenFetchStrategy } from '@headstartwp/core';
+import { fetchHookData } from '../../data';
+import { ERROR_MESSAGE } from './constants';
+
+/**
+ * This handler is used by `revalidateHandler` when the query includes the
+ * params needed to revalidate an archive.
+ *
+ * @param req The request object
+ * @param res The response object
+ *
+ * @returns A reponse object
+ */
+export async function revalidateArchive(req: NextApiRequest, res: NextApiResponse) {
+	const { post_type, path, locale, token } = req.query;
+	const total_pages = parseInt(req.query.total_pages as string, 10);
+
+	if (
+		typeof post_type !== 'string' ||
+		typeof path !== 'string' ||
+		isNaN(total_pages) ||
+		typeof token !== 'string'
+	) {
+		return res.status(401).json({ message: ERROR_MESSAGE.INVALID_PARAMS });
+	}
+
+	try {
+		const host = req.headers.host ?? '';
+		const site = getSiteByHost(host, typeof locale === 'string' ? locale : undefined);
+		const isMultisiteRequest = site !== null && typeof site.sourceUrl === 'string';
+		const { sourceUrl } = isMultisiteRequest ? site : getHeadlessConfig();
+
+		const { data } = await fetchHookData(
+			new VerifyTokenFetchStrategy(sourceUrl),
+			{
+				params: {
+					path: [],
+					site: host,
+				},
+				locale: typeof locale === 'string' ? locale : undefined,
+			},
+			{
+				params: {
+					authToken: token,
+				},
+			},
+		);
+
+		const result = data.result as any;
+		const verifiedPath = result.path ?? '';
+		const verifiedPostType = result.post_type ?? '';
+
+		// make sure the path and post_type matches with what was encoded in the token
+		if (verifiedPath !== path || verifiedPostType !== post_type) {
+			throw new Error(ERROR_MESSAGE.INVALID_TOKEN);
+		}
+
+		const pathsToRevalidate = [path]
+			.map((path) => {
+				// Create an array with the numbers of total pages to revalidate.
+				// If the page number is greater than 1, add the page sufix to the path.
+				const pagedPaths = Array.from({ length: total_pages }, (_, i) => i + 1).map(
+					(page: number) => {
+						return page > 1 ? `${path}/page/${page}` : path;
+					},
+				);
+
+				if (isMultisiteRequest) {
+					if (locale) {
+						return pagedPaths.map((path) => `/_sites/${host}/${locale}${path}`);
+					}
+
+					return pagedPaths.map((path) => `/_sites/${host}${path}`);
+				}
+
+				return pagedPaths;
+			})
+			.flat();
+
+		const revalidateResults = await Promise.all(
+			pathsToRevalidate.map(async (path) =>
+				res
+					.revalidate(path)
+					.then(() => path)
+					.catch(() => null),
+			),
+		);
+
+		const pathsRevalidated = revalidateResults.filter(Boolean);
+
+		return res.status(200).json({ message: 'success', paths: pathsRevalidated });
+	} catch (error) {
+		if (error instanceof Error) {
+			if (error.message === ERROR_MESSAGE.INVALID_TOKEN) {
+				return res.status(401).json({ message: error.message });
+			}
+
+			return res.status(500).json({ message: error.message });
+		}
+
+		return res.status(500).json({ message: ERROR_MESSAGE.GENERIC_SERVER_ERROR });
+	}
+}

--- a/wp/headless-wp/includes/classes/API/TokenEndpoint.php
+++ b/wp/headless-wp/includes/classes/API/TokenEndpoint.php
@@ -67,6 +67,7 @@ class TokenEndpoint {
 
 		return false;
 	}
+
 	/**
 	 * Returns the token payload.
 	 *
@@ -81,6 +82,15 @@ class TokenEndpoint {
 				[
 					'post_id' => $payload['post_id'],
 					'path'    => $payload['path'],
+				]
+			);
+		}
+
+		if ( isset( $payload['post_type'] ) ) {
+			return rest_ensure_response(
+				[
+					'post_type' => $payload['post_type'],
+					'path'      => $payload['path'],
 				]
 			);
 		}

--- a/wp/headless-wp/includes/classes/CacheFlush/CacheFlushToken.php
+++ b/wp/headless-wp/includes/classes/CacheFlush/CacheFlushToken.php
@@ -57,6 +57,36 @@ class CacheFlushToken extends BaseToken {
 	}
 
 	/**
+	 * Generates a cache flush token for the given archive.
+	 *
+	 * @param \WP_Post $post The post object.
+	 * @param string   $path The archive path.
+	 *
+	 * @return array
+	 */
+	public static function generateForArchive( $post, string $path ) {
+		$path = apply_filters(
+			'headless_wp_generate_token_for_archive_revalidate',
+			$path,
+			$post
+		);
+
+		$token = self::generate(
+			[
+				'post_type' => $post->post_type,
+				'path'      => $path,
+				'type'      => 'isr-revalidate',
+			]
+		);
+
+		return [
+			'token'     => $token,
+			'path'      => $path,
+			'post_type' => $post->post_type,
+		];
+	}
+
+	/**
 	 * Generates a cache flush token for the given terms.
 	 *
 	 * @param \WP_Term[] $terms The terms objects.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #295 

Parent PR #500 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
Implements the functionality to revalidate archive pages on demand.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @orballo 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
