### PR TITLE
use WordPress site name instead hardcoded name

### DIFF
--- a/projects/wp-nextjs/src/components/Header/Logo.js
+++ b/projects/wp-nextjs/src/components/Header/Logo.js
@@ -1,3 +1,4 @@
+import { useAppSettings } from '@headstartwp/next';
 import { css } from '@linaria/core';
 
 const logoStyles = css`
@@ -16,9 +17,15 @@ const logoStyles = css`
 `;
 
 export const Logo = () => {
+	const { data, loading } = useAppSettings();
+
+	if (loading) {
+		return null;
+	}
+
 	return (
 		<div className={logoStyles}>
-			<span>Brand Logo</span>
+			<span>{data?.settings?.site_name || 'Brand Logo'}</span>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR is a proposal. It would be nice if instead of "Brand Logo" the initial demo loaded the site name taken from WordPress using useAppSettings. 

NOTE: 

Creating the commit I have this error that I could not solve from the eslint configuration, so I disabled temporarily husky for this commit. `error  Unable to resolve path to module '@headstartwp/next'  import/no-unresolved`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
- use WordPress site name instead hardcoded name

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @riccardodicurti


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
