### PR TITLE
feat: set cookie path when entering preview mode

### DIFF
--- a/.changeset/lovely-chicken-sparkle.md
+++ b/.changeset/lovely-chicken-sparkle.md
@@ -1,0 +1,11 @@
+---
+"@headstartwp/next": minor
+"@headstartwp/headstartwp": patch
+"@headstartwp/core": patch
+---
+
+Improves the Next.js preview cookie handling and fixes a bug where the locale was not properly being passed from WP when previewing.
+
+First of all, it sets the preview cookie to expire within 5 minutes which aligns with the JWT token expiration.
+
+Secondly, it will narrow the cookie to the post path being previewed so that `context.preview` is not true for other paths and thus avoiding bypassing getStaticProps until the cookies are cleared (either expires or the browser closes).

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,16 +1,22 @@
-export type CustomPostTypes = Array<{
+export type CustomPostType = {
 	slug: string;
 	endpoint: string;
 	single?: string;
 	archive?: string;
-}>;
+};
+
+export type CustomPostTypes = Array<CustomPostType>;
+
 export type RedirectStrategy = '404' | 'none' | 'always';
-export type CustomTaxonomies = Array<{
+
+export type CustomTaxonomy = {
 	slug: string;
 	endpoint: string;
 	rewrite?: string;
 	restParam?: string;
-}>;
+};
+
+export type CustomTaxonomies = Array<CustomTaxonomy>;
 
 export interface Integration {
 	enable: boolean;

--- a/packages/next/src/handlers/__tests__/previewHandler.ts
+++ b/packages/next/src/handlers/__tests__/previewHandler.ts
@@ -51,4 +51,78 @@ describe('previewHandler', () => {
 		expect(res.setPreviewData).toHaveBeenCalled();
 		expect(res._getStatusCode()).toBe(302);
 	});
+
+	it('sets preview cookie path', async () => {
+		const { req, res } = createMocks({
+			method: 'GET',
+			query: { post_id: DRAFT_POST_ID, token: VALID_AUTH_TOKEN, post_type: 'post' },
+		});
+
+		res.setPreviewData = jest.fn();
+		await previewHandler(req, res);
+
+		expect(res.setPreviewData).toHaveBeenCalledWith(
+			{
+				authToken: 'this is a valid auth',
+				id: 57,
+				postType: 'post',
+				revision: false,
+			},
+			{ maxAge: 300, path: '/modi-qui-dignissimos-sed-assumenda-sint-iusto-preview=true' },
+		);
+		expect(res._getStatusCode()).toBe(302);
+	});
+
+	it('set preview cookie path to all paths if onRedirect is passed without getRedirectPath', async () => {
+		const { req, res } = createMocks({
+			method: 'GET',
+			query: { post_id: DRAFT_POST_ID, token: VALID_AUTH_TOKEN, post_type: 'post' },
+		});
+
+		res.setPreviewData = jest.fn();
+		await previewHandler(req, res, {
+			onRedirect(req, res) {
+				return res.redirect('/');
+			},
+		});
+
+		expect(res.setPreviewData).toHaveBeenCalledWith(
+			{
+				authToken: 'this is a valid auth',
+				id: 57,
+				postType: 'post',
+				revision: false,
+			},
+			{ maxAge: 300, path: '/' },
+		);
+		expect(res._getStatusCode()).toBe(302);
+	});
+
+	it('set preview cookie path redirectPath if getRedirectPath is passed', async () => {
+		const { req, res } = createMocks({
+			method: 'GET',
+			query: { post_id: DRAFT_POST_ID, token: VALID_AUTH_TOKEN, post_type: 'post' },
+		});
+
+		res.setPreviewData = jest.fn();
+		await previewHandler(req, res, {
+			getRedirectPath() {
+				return '/custom-redirect-path/';
+			},
+			onRedirect(req, res) {
+				return res.redirect('/');
+			},
+		});
+
+		expect(res.setPreviewData).toHaveBeenCalledWith(
+			{
+				authToken: 'this is a valid auth',
+				id: 57,
+				postType: 'post',
+				revision: false,
+			},
+			{ maxAge: 300, path: '/custom-redirect-path-preview=true' },
+		);
+		expect(res._getStatusCode()).toBe(302);
+	});
 });

--- a/packages/next/src/handlers/previewHandler.ts
+++ b/packages/next/src/handlers/previewHandler.ts
@@ -52,14 +52,14 @@ export type PreviewHandlerOptions = {
 	 * **Important**: You should not need to override this but if you do, uou must append `-preview=true` to the end of the redirecte path.
 	 *
 	 * @param defaultRedirectPath the default redirect path
-	 * @param result PostEntity
+	 * @param post PostEntity
 	 * @param postTypeDef The object describing a post type
 	 *
 	 * @returns the new redirect path
 	 */
 	getRedirectPath?: (
 		defaultRedirectPath: string,
-		result: any,
+		post: any,
 		postTypeDef: CustomPostType,
 	) => string;
 
@@ -223,7 +223,7 @@ export async function previewHandler(
 			});
 
 			const defaultRedirect: PreviewHandlerOptions['onRedirect'] = (req, res) => {
-				return res.redirect(getDefaultRedirectPath());
+				return res.redirect(redirectPath);
 			};
 
 			if (options?.onRedirect) {

--- a/wp/headless-wp/includes/classes/Preview/preview.php
+++ b/wp/headless-wp/includes/classes/Preview/preview.php
@@ -35,7 +35,7 @@ $preview_url = sprintf(
 	$post_type,
 	$is_revision ? '1' : '0',
 	$token,
-	Plugin::get_site_locale()
+	$locale
 );
 
 wp_redirect( $preview_url );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR improves the Next.js preview cookie handling. 

First of all, it sets the preview cookie to expire within 5 minutes which aligns with the JWT token expiration. 

Secondly, it will narrow the cookie to the post path being previewed so that `context.preview` is not true for other paths and thus avoiding bypassing `getStaticProps` (among other potential issues) until the cookies are cleared (either expires or the browser closes). 

This would also let us eventually get rid of the requirement of having "-preview=true" in the URL.

### How to test the Change

Preview a post and check if the cookies `__prerender_bypass` and `__next_preview_data` has `path` set to the actual path being previewed.
<img width="1511" alt="image" src="https://github.com/10up/headstartwp/assets/6104632/df12cc58-b6e7-4c92-bbd8-b06ba812cbf3">

Alternatively, you can also test with a production build whether `getStaticProps` are not running for every request after previewing a post.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
