### PR TITLE
Add target to Link component

### DIFF
--- a/projects/wp-nextjs/src/components/Link.js
+++ b/projects/wp-nextjs/src/components/Link.js
@@ -3,12 +3,12 @@ import { removeSourceUrl } from '@headstartwp/core';
 import { useSettings } from '@headstartwp/core/react';
 import NextLink from 'next/link';
 
-export const Link = ({ href, rel, children }) => {
+export const Link = ({ href, rel, children, target }) => {
 	const settings = useSettings();
 	const link = removeSourceUrl({ link: href, backendUrl: settings.sourceUrl || '' });
 
 	return (
-		<NextLink href={link} rel={rel}>
+		<NextLink href={link} rel={rel} target={target}>
 			{children}
 		</NextLink>
 	);
@@ -18,8 +18,10 @@ Link.propTypes = {
 	href: PropTypes.string.isRequired,
 	rel: PropTypes.string,
 	children: PropTypes.node.isRequired,
+	target: PropTypes.string,
 };
 
 Link.defaultProps = {
 	rel: '',
+	target: '',
 };


### PR DESCRIPTION
### Description of the Change
Extract from the Next.js documentation: <a> tag attributes such as className or target="_blank" can be added to <Link> as props and will be passed to the underlying <a> element.

I added target to the Link component as well so that it could be used for both internal andexternal link with target="_blank".

### How to test the Change
I tested the component manually

### Changelog Entry
> Changed - Link component

### Credits
Props @riccardodicurti 

### Checklist:
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
