### PR TITLE
fix(core): fixes useSearch not working when Yoast SEO is deactivated

### DIFF
--- a/.changeset/good-papayas-laugh.md
+++ b/.changeset/good-papayas-laugh.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": patch
+---
+
+Fixes useSearch error when Yoast SEO plugin is deactivated.

--- a/packages/core/src/data/strategies/SearchFetchStrategy.ts
+++ b/packages/core/src/data/strategies/SearchFetchStrategy.ts
@@ -48,6 +48,7 @@ export class SearchFetchStrategy<
 		let seo_json: Record<string, any> = {};
 		let seo: string = '';
 
+		// Request SEO data.
 		try {
 			const result = await apiGet(
 				addQueryArgs(`${getWPUrl()}${endpoints.yoast}`, {
@@ -57,7 +58,7 @@ export class SearchFetchStrategy<
 				burstCache,
 			);
 
-			seo = result.json.html;
+			seo = result.json.html ?? null;
 			seo_json = { ...result.json.json };
 		} catch (e) {
 			// do nothing


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Forces null over undefined when `seo` is undefined.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #565

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
