### PR TITLE
fix: getDefaultRedirectPath with locales

### DIFF
--- a/.changeset/thirty-buckets-vanish.md
+++ b/.changeset/thirty-buckets-vanish.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/next": patch
+---
+
+Fix bug where previews were not working with locales as the redirect path for the preview cookie was incorrect.

--- a/packages/next/src/handlers/__tests__/previewHandler.ts
+++ b/packages/next/src/handlers/__tests__/previewHandler.ts
@@ -73,6 +73,35 @@ describe('previewHandler', () => {
 		expect(res._getStatusCode()).toBe(302);
 	});
 
+	it('sets preview cookie path with locale', async () => {
+		const { req, res } = createMocks({
+			method: 'GET',
+			query: {
+				post_id: DRAFT_POST_ID,
+				token: VALID_AUTH_TOKEN,
+				post_type: 'post',
+				locale: 'es',
+			},
+		});
+
+		res.setPreviewData = jest.fn();
+		await previewHandler(req, res);
+
+		expect(res.setPreviewData).toHaveBeenCalledWith(
+			{
+				authToken: 'this is a valid auth',
+				id: 57,
+				postType: 'post',
+				revision: false,
+			},
+			{
+				maxAge: 300,
+				path: '/es/modi-qui-dignissimos-sed-assumenda-sint-iusto-preview=true',
+			},
+		);
+		expect(res._getStatusCode()).toBe(302);
+	});
+
 	it('set preview cookie path to all paths if onRedirect is passed without getRedirectPath', async () => {
 		const { req, res } = createMocks({
 			method: 'GET',

--- a/packages/next/src/handlers/previewHandler.ts
+++ b/packages/next/src/handlers/previewHandler.ts
@@ -194,12 +194,8 @@ export async function previewHandler(
 				const singleRoute = postTypeDef.single || '/';
 				const prefixRoute = singleRoute === '/' ? '' : singleRoute;
 				const slugOrId = revision ? post_id : slug || post_id;
-
-				if (locale) {
-					return `/${locale}/${prefixRoute}/${slugOrId}`;
-				}
-
-				return `${prefixRoute}/${slugOrId}`;
+				const path = [locale, prefixRoute, slugOrId].filter((n) => n).join('/');
+				return `/${path}`;
 			};
 
 			const redirectPath =


### PR DESCRIPTION
### Description of the Change
`prefixRoute` in `getDefaultRedirectPath` was sometimes an empty string. This resulted in the path being `/es//123-prevew=true` and therefore the preview would render a 404 page.

### How to test the Change

1. Test previews where locale is set in WP-Admin settings

### Changelog Entry
> Fixed - Fix bug where previews were not working with locales as the redirect path for the preview cookie was incorrect.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests pass.
