### PR TITLE
1.1.2

### DIFF
--- a/.changeset/thirty-buckets-vanish.md
+++ b/.changeset/thirty-buckets-vanish.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/next": patch
+---
+
+Fix bug where previews were not working with locales as the redirect path for the preview cookie was incorrect.

--- a/packages/next/src/handlers/__tests__/previewHandler.ts
+++ b/packages/next/src/handlers/__tests__/previewHandler.ts
@@ -73,6 +73,35 @@ describe('previewHandler', () => {
 		expect(res._getStatusCode()).toBe(302);
 	});
 
+	it('sets preview cookie path with locale', async () => {
+		const { req, res } = createMocks({
+			method: 'GET',
+			query: {
+				post_id: DRAFT_POST_ID,
+				token: VALID_AUTH_TOKEN,
+				post_type: 'post',
+				locale: 'es',
+			},
+		});
+
+		res.setPreviewData = jest.fn();
+		await previewHandler(req, res);
+
+		expect(res.setPreviewData).toHaveBeenCalledWith(
+			{
+				authToken: 'this is a valid auth',
+				id: 57,
+				postType: 'post',
+				revision: false,
+			},
+			{
+				maxAge: 300,
+				path: '/es/modi-qui-dignissimos-sed-assumenda-sint-iusto-preview=true',
+			},
+		);
+		expect(res._getStatusCode()).toBe(302);
+	});
+
 	it('set preview cookie path to all paths if onRedirect is passed without getRedirectPath', async () => {
 		const { req, res } = createMocks({
 			method: 'GET',

--- a/packages/next/src/handlers/previewHandler.ts
+++ b/packages/next/src/handlers/previewHandler.ts
@@ -194,12 +194,8 @@ export async function previewHandler(
 				const singleRoute = postTypeDef.single || '/';
 				const prefixRoute = singleRoute === '/' ? '' : singleRoute;
 				const slugOrId = revision ? post_id : slug || post_id;
-
-				if (locale) {
-					return `/${locale}/${prefixRoute}/${slugOrId}`;
-				}
-
-				return `${prefixRoute}/${slugOrId}`;
+				const path = [locale, prefixRoute, slugOrId].filter((n) => n).join('/');
+				return `/${path}`;
 			};
 
 			const redirectPath =


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
