### PR TITLE
fetchHookData with usePosts and throwIfNotFound set to false

### DIFF
--- a/.changeset/wild-pandas-tickle.md
+++ b/.changeset/wild-pandas-tickle.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": patch
+---
+
+Fix: fetchHookData with usePosts and throwIfNotFound set to false will crash the application if no results are found

--- a/packages/core/src/data/strategies/AbstractFetchStrategy.ts
+++ b/packages/core/src/data/strategies/AbstractFetchStrategy.ts
@@ -303,9 +303,15 @@ export abstract class AbstractFetchStrategy<E, Params extends EndpointParams, R 
 			throw new NotFoundError(`The request to ${url} returned no data`);
 		}
 
+		let resultData = result.json;
+		// if this didn't cause an error, default to an empty result set as this is the same as handling a NotFoundError without throwing
+		if (result.json.code === 'rest_post_invalid_page_number') {
+			resultData = [];
+		}
+
 		const page = Number(params.page) || 1;
 		const response: FetchResponse<E> = {
-			result: result.json,
+			result: resultData,
 			pageInfo: {
 				totalPages: Number(result.headers['x-wp-totalpages']) || 0,
 				totalItems: Number(result.headers['x-wp-total']) || 0,

--- a/packages/core/src/data/strategies/__tests__/PostOrPostsFetchStrategy.ts
+++ b/packages/core/src/data/strategies/__tests__/PostOrPostsFetchStrategy.ts
@@ -243,7 +243,7 @@ describe('PostOrPostsFetchStrategy', () => {
 			useWordPressPlugin: true,
 		});
 
-		const params = fetchStrategy.getParamsFromURL('/page/2');
+		const params = fetchStrategy.getParamsFromURL('/page/1');
 		const response = await fetchStrategy.fetcher(
 			'',
 			merge(params, { priority: 'single', routeMatchStrategy: 'archive' }),
@@ -257,7 +257,7 @@ describe('PostOrPostsFetchStrategy', () => {
 			useWordPressPlugin: true,
 		});
 
-		let params = fetchStrategy.getParamsFromURL('/page/2');
+		let params = fetchStrategy.getParamsFromURL('/page/1');
 		let response = await fetchStrategy.fetcher(
 			'',
 			merge(params, { priority: 'single', routeMatchStrategy: 'single' }),
@@ -265,7 +265,7 @@ describe('PostOrPostsFetchStrategy', () => {
 		expect(response.result.isSingle).toBeFalsy();
 		expect(response.result.isArchive).toBeTruthy();
 
-		params = fetchStrategy.getParamsFromURL('/page/2');
+		params = fetchStrategy.getParamsFromURL('/page/1');
 		response = await fetchStrategy.fetcher(
 			'',
 			merge(params, { priority: 'archive', routeMatchStrategy: 'single' }),

--- a/packages/core/src/react/hooks/__tests__/useFetchPosts.tsx
+++ b/packages/core/src/react/hooks/__tests__/useFetchPosts.tsx
@@ -189,6 +189,52 @@ describe('useFetchPosts', () => {
 		});
 	});
 
+	it('does not crash when not found but throwIfNotFound is set to false', async () => {
+		const { result } = renderHook(
+			() =>
+				useFetchPosts(
+					{ taxonomy: 'category' },
+					{
+						fetchStrategyOptions: {
+							throwIfNotFound: false,
+						},
+					},
+					'/i-do-not-exist',
+				),
+			{
+				wrapper,
+			},
+		);
+
+		await waitFor(() => {
+			expect(result.current.error).toBeFalsy();
+			expect(result.current.data?.posts.length).toBe(0);
+		});
+	});
+
+	it('does not crash when invalid page param when throwIfNotFound is set to false', async () => {
+		const { result } = renderHook(
+			() =>
+				useFetchPosts(
+					{ taxonomy: 'category' },
+					{
+						fetchStrategyOptions: {
+							throwIfNotFound: false,
+						},
+					},
+					'/news/page/10',
+				),
+			{
+				wrapper,
+			},
+		);
+
+		await waitFor(() => {
+			expect(result.current.error).toBeFalsy();
+			expect(result.current.data?.posts.length).toBe(0);
+		});
+	});
+
 	describe('useFetchPosts types', () => {
 		it('allows overriding types', () => {
 			interface Book extends PostEntity {

--- a/packages/core/test/server-handlers.ts
+++ b/packages/core/test/server-handlers.ts
@@ -47,6 +47,7 @@ const handlers = [
 		const search = query.get('search');
 		const slug = query.get('slug');
 		const perPage = Number(query.get('per_page') || 10);
+		const page = Number(query.get('page') || 1);
 		const category = query.get('categories');
 		const author = query.get('author');
 		const embed = query.get('_embed');
@@ -107,8 +108,21 @@ const handlers = [
 
 		const totalResults = results.length;
 
+		if ((page - 1) * perPage > totalResults) {
+			return res(
+				ctx.json({
+					code: 'rest_post_invalid_page_number',
+					message:
+						'The page number requested is larger than the number of pages available.',
+					data: {
+						status: 400,
+					},
+				}),
+			);
+		}
+
 		if (perPage) {
-			results = results.slice(0, perPage);
+			results = results.slice((page - 1) * perPage, perPage);
 		}
 
 		return res(

--- a/projects/wp-nextjs/src/pages/category/[...path].js
+++ b/projects/wp-nextjs/src/pages/category/[...path].js
@@ -34,6 +34,9 @@ export async function getServerSideProps(context) {
 		const settledPromises = await resolveBatch([
 			{
 				func: fetchHookData(usePosts.fetcher(), context, {
+					fetchStrategyOptions: {
+						throwIfNotFound: false,
+					},
 					params: { taxonomy: 'category' },
 				}),
 			},

--- a/projects/wp-nextjs/src/pages/category/[...path].js
+++ b/projects/wp-nextjs/src/pages/category/[...path].js
@@ -34,9 +34,6 @@ export async function getServerSideProps(context) {
 		const settledPromises = await resolveBatch([
 			{
 				func: fetchHookData(usePosts.fetcher(), context, {
-					fetchStrategyOptions: {
-						throwIfNotFound: false,
-					},
 					params: { taxonomy: 'category' },
 				}),
 			},


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #610 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
See steps to reproduce the associated issue and confirm the original error is not throwing anymore, the error should be about accessing `data.queriedObject.term.name` which isn't set. This is expected given that when `thowIfNotFound` is set to false, no results handling should be done at the page level.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Thanks @chriseagle for reporting.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
