### PR TITLE
Fix deprecation warning for htmlspecialchars

### DIFF
--- a/.changeset/cyan-badgers-smile.md
+++ b/.changeset/cyan-badgers-smile.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/headstartwp": patch
+---
+
+Ensure htmlspecialchars receives an empty string instead of null to fix deprecation warnings.

--- a/wp/headless-wp/includes/classes/API.php
+++ b/wp/headless-wp/includes/classes/API.php
@@ -98,7 +98,7 @@ class API {
 			return $args;
 		}
 
-		$author = htmlspecialchars( filter_input( INPUT_GET, 'author' ) );
+		$author = htmlspecialchars( filter_input( INPUT_GET, 'author' ) ?? '' );
 
 		if ( ! empty( $author ) && ! is_numeric( $author ) ) {
 			unset( $args['author__in'] );
@@ -108,10 +108,10 @@ class API {
 		$taxonomies = wp_list_filter( get_object_taxonomies( $args['post_type'], 'objects' ), [ 'show_in_rest' => true ] );
 
 		foreach ( $taxonomies as $taxonomy ) {
-			$term = htmlspecialchars( filter_input( INPUT_GET, $taxonomy->name ) );
+			$term = htmlspecialchars( filter_input( INPUT_GET, $taxonomy->name ) ?? '' );
 
 			if ( ! $term ) {
-				$term = htmlspecialchars( filter_input( INPUT_GET, $taxonomy->rest_base ) );
+				$term = htmlspecialchars( filter_input( INPUT_GET, $taxonomy->rest_base ) ?? '' );
 			}
 
 			if ( ! empty( $term ) && ! is_numeric( $term ) ) {


### PR DESCRIPTION

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #669 

Defaults the result of filter_input to an empty string instead of null before passing it to `htmlspecialchars`.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Start up the dev app from a fresh copy of the repo. After the app starts, you will immediately see the deprecation warning at http://localhost:8888/wp-json/wp/v2/pages. This will also cause API request parsing in the app to fail.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Ensure `htmlspecialchars` receives an empty string instead of null to fix deprecation warnings.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
@johnwatkins0 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
