### PR TITLE
WP Plugin - PHPCS - Force short array syntax

### DIFF
--- a/wp/headless-wp/includes/classes/API.php
+++ b/wp/headless-wp/includes/classes/API.php
@@ -35,7 +35,7 @@ class API {
 		$token_endpoint = new API\TokenEndpoint();
 		$token_endpoint->register();
 
-		add_action( 'init', array( $this, 'register_post_type_taxonomy_params' ), 999 );
+		add_action( 'init', [ $this, 'register_post_type_taxonomy_params' ], 999 );
 	}
 
 	/**
@@ -45,14 +45,14 @@ class API {
 	public function register_post_type_taxonomy_params() {
 
 		$post_types = get_post_types(
-			array(
+			[
 				'show_in_rest' => true,
 				'public'       => true,
-			)
+			]
 		);
 
 		foreach ( $post_types as $post_type ) {
-			add_filter( "rest_{$post_type}_query", array( $this, 'modify_rest_params' ), 10, 1 );
+			add_filter( "rest_{$post_type}_query", [ $this, 'modify_rest_params' ], 10, 1 );
 			add_filter( "rest_{$post_type}_collection_params", [ $this, 'modify_rest_params_schema' ], 10, 2 );
 		}
 	}
@@ -126,12 +126,12 @@ class API {
 						$args['tax_query']
 					);
 				} else {
-					$args['tax_query'][] = array(
+					$args['tax_query'][] = [
 						'taxonomy'         => $taxonomy->name,
 						'field'            => 'slug',
 						'terms'            => sanitize_text_field( $term ),
 						'include_children' => false,
-					);
+					];
 				}
 			}
 		}

--- a/wp/headless-wp/includes/classes/API/AppEndpoint.php
+++ b/wp/headless-wp/includes/classes/API/AppEndpoint.php
@@ -132,10 +132,10 @@ class AppEndpoint {
 			// Specify any data that will be needed to retrieve the homepage
 			$response['home'] = apply_filters(
 				'headless_wp_api_app_home',
-				array(
+				[
 					'id'   => $homepage_id,
 					'slug' => $home_page_post_slug,
-				)
+				]
 			);
 
 			// Set up menu data to return for REST API

--- a/wp/headless-wp/includes/classes/API/TokenEndpoint.php
+++ b/wp/headless-wp/includes/classes/API/TokenEndpoint.php
@@ -19,7 +19,7 @@ class TokenEndpoint {
 	 * Registers hooks.
 	 */
 	public function register() {
-		add_action( 'rest_api_init', array( $this, 'register_rest_route' ) );
+		add_action( 'rest_api_init', [ $this, 'register_rest_route' ] );
 	}
 
 	/**
@@ -34,8 +34,8 @@ class TokenEndpoint {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
 				],
 			]
 		);

--- a/wp/headless-wp/includes/classes/BaseToken.php
+++ b/wp/headless-wp/includes/classes/BaseToken.php
@@ -91,7 +91,7 @@ abstract class BaseToken {
 			$payload = JWT::decode(
 				$token,
 				self::get_private_key(),
-				array( 'HS256' )
+				[ 'HS256' ]
 			);
 		} catch ( \Exception $e ) {
 			// Token is not valid.

--- a/wp/headless-wp/includes/classes/Integrations/YoastSEO.php
+++ b/wp/headless-wp/includes/classes/Integrations/YoastSEO.php
@@ -18,21 +18,21 @@ class YoastSEO {
 	 */
 	public function register() {
 		// Override sitemap stylesheet.
-		add_filter( 'wpseo_stylesheet_url', array( $this, 'override_wpseo_stylesheet_url' ) );
+		add_filter( 'wpseo_stylesheet_url', [ $this, 'override_wpseo_stylesheet_url' ] );
 
 		// Override url in sitemap at root/index.
-		add_filter( 'wpseo_sitemap_index_links', array( $this, 'maybe_override_sitemap_index_links' ) );
+		add_filter( 'wpseo_sitemap_index_links', [ $this, 'maybe_override_sitemap_index_links' ] );
 
 		// Override url in sitemap for posts, pages, taxonomy archives, authors etc.
-		add_filter( 'wpseo_sitemap_url', array( $this, 'maybe_override_sitemap_url' ), 10, 1 );
+		add_filter( 'wpseo_sitemap_url', [ $this, 'maybe_override_sitemap_url' ], 10, 1 );
 
-		add_filter( 'robots_txt', array( $this, 'maybe_override_sitemap_robots_url' ), 999999 );
+		add_filter( 'robots_txt', [ $this, 'maybe_override_sitemap_robots_url' ], 999999 );
 
 		// Override Search results yoast head, get_head endpoint currently does't detect search page.
-		add_filter( 'wpseo_canonical', array( $this, 'override_search_canonical' ), 10, 1 );
-		add_filter( 'wpseo_title', array( $this, 'override_search_title' ), 10, 1 );
-		add_filter( 'wpseo_opengraph_title', array( $this, 'override_search_title' ), 10, 1 );
-		add_filter( 'wpseo_opengraph_url', array( $this, 'override_search_canonical' ), 10, 1 );
+		add_filter( 'wpseo_canonical', [ $this, 'override_search_canonical' ], 10, 1 );
+		add_filter( 'wpseo_title', [ $this, 'override_search_title' ], 10, 1 );
+		add_filter( 'wpseo_opengraph_title', [ $this, 'override_search_title' ], 10, 1 );
+		add_filter( 'wpseo_opengraph_url', [ $this, 'override_search_canonical' ], 10, 1 );
 	}
 
 	/**
@@ -219,12 +219,12 @@ class YoastSEO {
 
 		$str_replace_mapping = apply_filters(
 			'tenup_headless_wp_search_title_variables_replacments',
-			array(
+			[
 				'%%sitename%%'     => get_bloginfo( 'name' ),
 				'%%searchphrase%%' => $query_vars['s'] ?? '',
 				' %%page%%'        => ! empty( $query_vars['page'] ) ? sprintf( ' %s %d', __( 'Page', 'headless-wp' ), $query_vars['page'] ) : '',
 				'%%sep%%'          => \YoastSEO()->helpers->options->get_title_separator() ?? ' ',
-			)
+			]
 		);
 
 		return str_replace( array_keys( $str_replace_mapping ), array_values( $str_replace_mapping ), $title );

--- a/wp/headless-wp/includes/classes/Links.php
+++ b/wp/headless-wp/includes/classes/Links.php
@@ -19,8 +19,8 @@ class Links {
 	 * Set up any hooks
 	 */
 	public function register() {
-		add_action( 'template_redirect', array( $this, 'maybe_redirect_frontend' ) );
-		add_filter( 'rewrite_rules_array', array( $this, 'create_taxonomy_rewrites' ) );
+		add_action( 'template_redirect', [ $this, 'maybe_redirect_frontend' ] );
+		add_filter( 'rewrite_rules_array', [ $this, 'create_taxonomy_rewrites' ] );
 	}
 
 	/**
@@ -44,10 +44,10 @@ class Links {
 		}
 
 		$post_types = get_post_types(
-			array(
+			[
 				'show_in_rest' => true,
 				'public'       => true,
-			)
+			]
 		);
 
 		unset( $post_types['page'] );

--- a/wp/headless-wp/includes/classes/Plugin.php
+++ b/wp/headless-wp/includes/classes/Plugin.php
@@ -89,7 +89,7 @@ class Plugin {
 		register_setting(
 			'general',
 			'site_react_url',
-			array( 'sanitize_callback' => 'esc_url_raw' )
+			[ 'sanitize_callback' => 'esc_url_raw' ]
 		);
 
 		// Register the settings
@@ -114,7 +114,7 @@ class Plugin {
 		register_setting(
 			'general',
 			'headless_site_locale',
-			array( 'sanitize_callback' => 'esc_attr' )
+			[ 'sanitize_callback' => 'esc_attr' ]
 		);
 
 		add_settings_field(
@@ -139,7 +139,7 @@ class Plugin {
 		register_setting(
 			'general',
 			'site_react_redirect',
-			array( 'sanitize_callback' => 'intval' )
+			[ 'sanitize_callback' => 'intval' ]
 		);
 
 		// Register the settings
@@ -167,7 +167,7 @@ class Plugin {
 		register_setting(
 			'general',
 			'headless_isr_revalidate',
-			array( 'sanitize_callback' => 'intval' )
+			[ 'sanitize_callback' => 'intval' ]
 		);
 
 		add_settings_field(

--- a/wp/headless-wp/includes/classes/Preview/PreviewToken.php
+++ b/wp/headless-wp/includes/classes/Preview/PreviewToken.php
@@ -71,11 +71,11 @@ class PreviewToken extends BaseToken {
 
 		// Allowed capabilities when the token is type 'preview'. You also need to
 		// have permission to 'edit_post' or 'delete_post' for preview posts.
-		$capabilities = array(
+		$capabilities = [
 			'read_post'   => $post_id,
 			'edit_post'   => $post_id,
 			'delete_post' => $post_id,
-		);
+		];
 
 		// Prior to WordPress 5.5.1, capabilities should be specified with `page`
 		// for pages, so we are adding them as well to support older versions of
@@ -83,11 +83,11 @@ class PreviewToken extends BaseToken {
 		if ( 'page' === $post_type ) {
 			$capabilities = array_merge(
 				$capabilities,
-				array(
+				[
 					'read_page'   => $post_id,
 					'edit_page'   => $post_id,
 					'delete_page' => $post_id,
-				)
+				]
 			);
 		}
 

--- a/wp/headless-wp/includes/classes/php-jwt/BeforeValidException.php
+++ b/wp/headless-wp/includes/classes/php-jwt/BeforeValidException.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:ignoreFile
+
 namespace HeadlessWP\JWT;
 
 class BeforeValidException extends \UnexpectedValueException {

--- a/wp/headless-wp/includes/classes/php-jwt/ExpiredException.php
+++ b/wp/headless-wp/includes/classes/php-jwt/ExpiredException.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:ignoreFile
+
 namespace HeadlessWP\JWT;
 
 class ExpiredException extends \UnexpectedValueException {

--- a/wp/headless-wp/includes/classes/php-jwt/JWK.php
+++ b/wp/headless-wp/includes/classes/php-jwt/JWK.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:ignoreFile
+
 namespace HeadlessWP\JWT;
 
 use DomainException;

--- a/wp/headless-wp/includes/classes/php-jwt/JWT.php
+++ b/wp/headless-wp/includes/classes/php-jwt/JWT.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:ignoreFile
+
 namespace HeadlessWP\JWT;
 
 use \DomainException;

--- a/wp/headless-wp/includes/classes/php-jwt/SignatureInvalidException.php
+++ b/wp/headless-wp/includes/classes/php-jwt/SignatureInvalidException.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:ignoreFile
+
 namespace HeadlessWP\JWT;
 
 class SignatureInvalidException extends \UnexpectedValueException {

--- a/wp/headless-wp/phpcs.xml
+++ b/wp/headless-wp/phpcs.xml
@@ -6,10 +6,17 @@
 	<!-- What to scan -->
 	<file>.</file>
 
+	<!-- What not to scan -->
+	<exclude-pattern>rector.php</exclude-pattern>
+	<exclude-pattern>jwt</exclude-pattern>
+
 	<!-- Options -->
 	<arg value="sp"/>
 	<arg name="colors"/>
 	<arg name="basepath" value="."/>
+
+	<!-- Force short array syntax -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
 	<!-- Disallowed functions -->
 	<rule ref="Generic.PHP.ForbiddenFunctions">


### PR DESCRIPTION
### Description of the Change
Automatic linting PR to enforce short array syntax.

Require #689 

Part 3 for addressing https://github.com/10up/headstartwp/issues/625

### Changelog Entry
> Changed - Enforce short array syntax

### Credits
Props @claytoncollie
