### PR TITLE
fix: make convertUrl and removeSourceUrl respect the original link's railingslash

### DIFF
--- a/.changeset/lucky-doors-applaud.md
+++ b/.changeset/lucky-doors-applaud.md
@@ -1,0 +1,6 @@
+---
+"@headstartwp/core": patch
+"@headstartwp/next": patch
+---
+
+fix: make convertUrl and removeSourceUrl respect the original link's trailingslash

--- a/packages/core/src/utils/__tests__/removeSourceUrl.ts
+++ b/packages/core/src/utils/__tests__/removeSourceUrl.ts
@@ -4,6 +4,20 @@ describe('removeSourceUrl', () => {
 	it('removes source url', () => {
 		expect(
 			removeSourceUrl({
+				link: 'https://test.com/test',
+				backendUrl: 'https://test.com/test',
+			}),
+		).toBe('/');
+
+		expect(
+			removeSourceUrl({
+				link: 'http://backendurl.com',
+				backendUrl: 'https://backendurl.com',
+			}),
+		).toBe('/');
+
+		expect(
+			removeSourceUrl({
 				link: 'http://backendurl.com/',
 				backendUrl: 'https://backendurl.com',
 			}),
@@ -43,6 +57,13 @@ describe('removeSourceUrl', () => {
 				backendUrl: 'https://backendurl.com/',
 			}),
 		).toBe('/post-name-1?a=1&b=3&d=3');
+
+		expect(
+			removeSourceUrl({
+				link: 'http://backendurl.com/post-name-1?a=1&b=3&d=3/',
+				backendUrl: 'https://backendurl.com/',
+			}),
+		).toBe('/post-name-1?a=1&b=3&d=3/');
 
 		expect(
 			removeSourceUrl({

--- a/packages/core/src/utils/__tests__/removeSourceUrl.ts
+++ b/packages/core/src/utils/__tests__/removeSourceUrl.ts
@@ -1,6 +1,15 @@
 import { removeSourceUrl } from '..';
 
 describe('removeSourceUrl', () => {
+	it('returns empty string without nonEmptyLink', () => {
+		expect(
+			removeSourceUrl({
+				link: 'https://test.com/test',
+				backendUrl: 'https://test.com/test',
+				nonEmptyLink: false,
+			}),
+		).toBe('');
+	});
 	it('removes source url', () => {
 		expect(
 			removeSourceUrl({

--- a/packages/core/src/utils/removeSourceUrl.ts
+++ b/packages/core/src/utils/removeSourceUrl.ts
@@ -20,7 +20,7 @@ export type removeSourceUrlType = {
 	 * If the removal of source url from link leads to a empty string,
 	 * this setting control whether a '/' should be returned or the empty string
 	 */
-	nonEmptyLinks?: boolean;
+	nonEmptyLink?: boolean;
 };
 
 /**
@@ -43,7 +43,7 @@ export function removeSourceUrl({
 	link: originalLink,
 	backendUrl,
 	publicUrl = '/',
-	nonEmptyLinks = true,
+	nonEmptyLink = true,
 }: removeSourceUrlType) {
 	if (typeof originalLink === 'undefined') {
 		warn('link is undefined, double check if you are passing a valid value');
@@ -80,7 +80,7 @@ export function removeSourceUrl({
 
 		transformedLink = hasTrailingSlash ? transformedLink : transformedLink.replace(/\/?$/, '');
 
-		if (nonEmptyLinks && transformedLink === '') {
+		if (nonEmptyLink && transformedLink === '') {
 			return '/';
 		}
 

--- a/packages/core/src/utils/removeSourceUrl.ts
+++ b/packages/core/src/utils/removeSourceUrl.ts
@@ -15,6 +15,12 @@ export type removeSourceUrlType = {
 	 * The public url. Defaults to '/'.
 	 */
 	publicUrl?: string;
+
+	/**
+	 * If the removal of source url from link leads to a empty string,
+	 * this setting control whether a '/' should be returned or the empty string
+	 */
+	nonEmptyLinks?: boolean;
 };
 
 /**
@@ -25,17 +31,28 @@ export type removeSourceUrlType = {
  *
  * @see https://github.com/frontity/frontity/blob/dev/packages/components/link/utils.ts
  *
+ * @param props.link The link that might contain the sourceUrl
+ * @param props.backendUrl The source url
+ * @param props.publicUrl The public url
+ * @param props.nonEmptyLinks If the removal of source url from link leads to a empty string,
+ * this setting control whether a '/' should be returned or the empty string
+ *
  * @returns The URL without the Source URL.
  */
-export function removeSourceUrl({ link, backendUrl, publicUrl = '/' }: removeSourceUrlType) {
-	if (typeof link === 'undefined') {
+export function removeSourceUrl({
+	link: originalLink,
+	backendUrl,
+	publicUrl = '/',
+	nonEmptyLinks = true,
+}: removeSourceUrlType) {
+	if (typeof originalLink === 'undefined') {
 		warn('link is undefined, double check if you are passing a valid value');
 		return '';
 	}
 
 	if (typeof backendUrl === 'undefined') {
 		warn('backendUrl is undefined, double check if you are passing a valid value');
-		return link;
+		return originalLink;
 	}
 
 	// Ensure `sourceUrl` and `publicUrl` always include a trailing slash. All
@@ -43,21 +60,33 @@ export function removeSourceUrl({ link, backendUrl, publicUrl = '/' }: removeSou
 	const sourceUrl = backendUrl.replace(/\/?$/, '/');
 	const appUrl = publicUrl.replace(/\/?$/, '/');
 
-	if (sourceUrl === '/' || link.startsWith('#')) {
-		return link;
+	if (sourceUrl === '/' || originalLink.startsWith('#')) {
+		return originalLink;
 	}
 
 	const { host: sourceHost, pathname: sourcePath } = new URL(sourceUrl);
 	const { pathname: appPath } = new URL(appUrl, sourceUrl);
 
+	// we need to know if the original link has trailing slash or not
+	const hasTrailingSlash = /\/$/.test(originalLink);
+	const link = !hasTrailingSlash ? `${originalLink}/` : originalLink;
 	const linkUrl = new URL(link, sourceUrl);
 
 	// Compare just the host and the pathname. This way we ignore the protocol if
 	// it doesn't match.
 	if (linkUrl.host === sourceHost && linkUrl.pathname.startsWith(sourcePath)) {
-		return linkUrl.pathname.replace(sourcePath, appPath) + linkUrl.search + linkUrl.hash;
+		let transformedLink =
+			linkUrl.pathname.replace(sourcePath, appPath) + linkUrl.search + linkUrl.hash;
+
+		transformedLink = hasTrailingSlash ? transformedLink : transformedLink.replace(/\/?$/, '');
+
+		if (nonEmptyLinks && transformedLink === '') {
+			return '/';
+		}
+
+		return transformedLink;
 	}
 
 	// Do not change the link for other cases.
-	return link;
+	return originalLink;
 }

--- a/packages/next/src/components/Yoast.tsx
+++ b/packages/next/src/components/Yoast.tsx
@@ -21,7 +21,7 @@ export function convertUrl(url: string, hostUrl: string, sourceUrl: string) {
 		link: url,
 		publicUrl: hostUrl,
 		backendUrl: sourceUrl,
-		nonEmptyLinks: false,
+		nonEmptyLink: false,
 	})}`;
 }
 

--- a/packages/next/src/components/Yoast.tsx
+++ b/packages/next/src/components/Yoast.tsx
@@ -18,8 +18,10 @@ export function convertUrl(url: string, hostUrl: string, sourceUrl: string) {
 	}
 
 	return `${hostUrl}${removeSourceUrl({
-		link: url.replace(/\/?$/, '/'),
+		link: url,
+		publicUrl: hostUrl,
 		backendUrl: sourceUrl,
+		nonEmptyLinks: false,
 	})}`;
 }
 

--- a/packages/next/src/components/__tests__/Yoast.tsx
+++ b/packages/next/src/components/__tests__/Yoast.tsx
@@ -1,16 +1,60 @@
 import { convertUrl } from '../Yoast';
 
 describe('convertUrl', () => {
-	it('root works without trailing slash', () => {
+	it('works without trainling slash', () => {
 		expect(
-			convertUrl('https://test.com/test', 'https://test.test.com', 'https://test.com/test'),
-		).toBe('https://test.test.com/');
+			convertUrl(
+				'https://backendurl.com/test',
+				'https://publicurl.com',
+				'https://backendurl.com/test',
+			),
+		).toBe('https://publicurl.com');
+
+		// a subsite on test.com/site1
+		expect(
+			convertUrl(
+				'https://backendurl.com/site1/post-name-1',
+				'https://publicurl.com',
+				'https://backendurl.com/site1',
+			),
+		).toBe('https://publicurl.com/post-name-1');
+
+		// front-end with subdomain
+		expect(
+			convertUrl(
+				'https://backendurl.com/site1/post-name-1',
+				'https://site1.publicurl.com',
+				'https://backendurl.com/site1',
+			),
+		).toBe('https://site1.publicurl.com/post-name-1');
 	});
 
 	it('root works with trailing slash', () => {
 		expect(
-			convertUrl('https://test.com/test/', 'https://test.test.com', 'https://test.com/test'),
-		).toBe('https://test.test.com/');
+			convertUrl(
+				'https://backendurl.com/test/',
+				'https://publicurl.com',
+				'https://backendurl.com/test',
+			),
+		).toBe('https://publicurl.com/');
+
+		// a subsite on test.com/site1
+		expect(
+			convertUrl(
+				'https://backendurl.com/site1/post-name-1/',
+				'https://publicurl.com',
+				'https://backendurl.com/site1',
+			),
+		).toBe('https://publicurl.com/post-name-1/');
+
+		// front-end with subdomain
+		expect(
+			convertUrl(
+				'https://backendurl.com/site1/post-name-1/',
+				'https://site1.publicurl.com',
+				'https://backendurl.com/site1',
+			),
+		).toBe('https://site1.publicurl.com/post-name-1/');
 	});
 
 	it('external url returns external url', () => {


### PR DESCRIPTION


<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #710 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @johnwatkins0 (reporting the bug)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
