### PR TITLE
Feature/support params for YoutubeLiteBlock

### DIFF
--- a/.changeset/fuzzy-bees-speak.md
+++ b/.changeset/fuzzy-bees-speak.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": patch
+---
+
+Pass params attr to YoutubeLiteBlock

--- a/packages/core/src/react/blocks/YoutubeLiteBlock.tsx
+++ b/packages/core/src/react/blocks/YoutubeLiteBlock.tsx
@@ -28,6 +28,7 @@ declare global {
 export interface YoutubeLiteBlockProps extends IBlockAttributes {
 	src: string;
 	title: string;
+	params: string;
 }
 
 export interface IYoutubeLiteBlock extends IBlock<YoutubeLiteBlockProps> {}
@@ -55,11 +56,11 @@ export function YoutubeLiteBlock({ domNode }: Omit<IYoutubeLiteBlock, 'component
 		}
 	}
 
-	const { src, title } = attribs;
+	const { src, title, params } = attribs;
 
 	const videoId = src.match(youtubeEmbedRegex)?.[7];
 
-	return <lite-youtube videoid={videoId} videotitle={title} />;
+	return <lite-youtube videoid={videoId} videotitle={title} params={params} />;
 }
 
 /**

--- a/packages/core/src/react/blocks/YoutubeLiteBlock.tsx
+++ b/packages/core/src/react/blocks/YoutubeLiteBlock.tsx
@@ -56,11 +56,15 @@ export function YoutubeLiteBlock({ domNode }: Omit<IYoutubeLiteBlock, 'component
 		}
 	}
 
-	const { src, title, params = '' } = attribs;
+	const { src, title, params } = attribs;
 
 	const videoId = src.match(youtubeEmbedRegex)?.[7];
 
-	return <lite-youtube videoid={videoId} videotitle={title} params={params} />;
+	if (params) {
+		return <lite-youtube videoid={videoId} videotitle={title} params={params} />;
+	}
+
+	return <lite-youtube videoid={videoId} videotitle={title} />;
 }
 
 /**

--- a/packages/core/src/react/blocks/YoutubeLiteBlock.tsx
+++ b/packages/core/src/react/blocks/YoutubeLiteBlock.tsx
@@ -28,7 +28,7 @@ declare global {
 export interface YoutubeLiteBlockProps extends IBlockAttributes {
 	src: string;
 	title: string;
-	params: string;
+	params?: string;
 }
 
 export interface IYoutubeLiteBlock extends IBlock<YoutubeLiteBlockProps> {}
@@ -56,7 +56,7 @@ export function YoutubeLiteBlock({ domNode }: Omit<IYoutubeLiteBlock, 'component
 		}
 	}
 
-	const { src, title, params } = attribs;
+	const { src, title, params = '' } = attribs;
 
 	const videoId = src.match(youtubeEmbedRegex)?.[7];
 


### PR DESCRIPTION
### Description of the Change

Add params to the `YoutubeLiteBlock` which is supported by https://github.com/paulirish/lite-youtube-embed?tab=readme-ov-file#custom-player-parameters

This should allow greater control of the YouTube embed using the params passed in with the URL. For example, `&rel=0` can be passed to disable related videos loading. At the moment, these params are not passed.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
