### PR TITLE
feat: add cache-healthcheck to matcher config in wp-nextjs

### DIFF
--- a/projects/wp-multisite-i18n-nextjs/src/middleware.js
+++ b/projects/wp-multisite-i18n-nextjs/src/middleware.js
@@ -11,7 +11,7 @@ export const config = {
 		 * 3. /fonts (inside /public)
 		 * 4. all root files inside /public (e.g. /favicon.ico)
 		 */
-		'/((?!api|_next|fonts[\\w-]+\\.\\w+).*)',
+		'/((?!api|cache-healthcheck|_next|fonts[\\w-]+\\.\\w+).*)',
 	],
 };
 

--- a/projects/wp-multisite-nextjs/src/middleware.js
+++ b/projects/wp-multisite-nextjs/src/middleware.js
@@ -9,7 +9,7 @@ export const config = {
 		 * 3. /fonts (inside /public)
 		 * 4. all root files inside /public (e.g. /favicon.ico)
 		 */
-		'/((?!api|_next|fonts[\\w-]+\\.\\w+).*)',
+		'/((?!api|cache-healthcheck|_next|fonts[\\w-]+\\.\\w+).*)',
 	],
 };
 

--- a/projects/wp-nextjs/src/middleware.js
+++ b/projects/wp-nextjs/src/middleware.js
@@ -9,7 +9,7 @@ export const config = {
 		 * 3. /fonts (inside /public)
 		 * 4. all root files inside /public (e.g. /favicon.ico)
 		 */
-		'/((?!api|_next|fonts[\\w-]+\\.\\w+).*)',
+		'/((?!api|cache-healthcheck|_next|fonts[\\w-]+\\.\\w+).*)',
 	],
 };
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #777 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
