### PR TITLE
feat: modify image config depending on next version

### DIFF
--- a/.changeset/happy-bugs-obey.md
+++ b/.changeset/happy-bugs-obey.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/next": patch
+---
+
+Opt into image.remotePatters for Next.js versions that supports it

--- a/packages/next/src/config/withHeadstartWPConfig.ts
+++ b/packages/next/src/config/withHeadstartWPConfig.ts
@@ -1,12 +1,13 @@
 import { ConfigError, HeadlessConfig } from '@headstartwp/core';
 import { NextConfig } from 'next';
 import fs from 'fs';
-import path from 'path';
 import { ModifySourcePlugin, ConcatOperation } from './plugins/ModifySourcePlugin';
 
-// Get the path to the project's root package.json
-const packageJsonPath = path.join(process.cwd(), 'package.json');
-const packageJson = packageJsonPath ? JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) : {};
+// Use require.resolve to get the path to the package.json
+const nextPackageJsonPath = require.resolve('next/package.json');
+const nextPackageJson = nextPackageJsonPath
+	? JSON.parse(fs.readFileSync(nextPackageJsonPath, 'utf8'))
+	: {};
 
 type RemotePattern = {
 	protocol?: 'http' | 'https';
@@ -148,7 +149,7 @@ export function withHeadstartWPConfig(
 		}
 	});
 
-	const useImageRemotePatterns = meetsMinimumVersion(packageJson?.dependencies?.next, 14);
+	const useImageRemotePatterns = meetsMinimumVersion(nextPackageJson?.version, 14);
 	const imageConfig: { domains?: string[]; remotePatterns?: RemotePattern[] } = {};
 
 	if (useImageRemotePatterns) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
`images.remotePatterns` requires a minimum Next.js version, 14. Rather than updating the config to always use `remotePatterns`, this change will detect the Next version from the project's `package.json` file, and then use `remotePatterns` if the version is >=14 or `domains` if the version is <14.

Closes https://github.com/10up/headstartwp/issues/812

### Changelog Entry
Added check for Next version and configuration properties.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
