### PR TITLE
fix: only validate a locale based on the configuration

### DIFF
--- a/.changeset/itchy-cooks-tap.md
+++ b/.changeset/itchy-cooks-tap.md
@@ -2,4 +2,5 @@
 "@headstartwp/next": patch
 ---
 
-Fix
+Fixed - Fixed isValidLocale function to validate against the configuration
+Added - New test condition for technically valid, but unsupported locale

--- a/.changeset/itchy-cooks-tap.md
+++ b/.changeset/itchy-cooks-tap.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/next": patch
+---
+
+Fix

--- a/packages/next/src/middlewares/appMidleware.ts
+++ b/packages/next/src/middlewares/appMidleware.ts
@@ -23,14 +23,6 @@ function isPolylangIntegrationEnabled() {
 	return config.integrations?.polylang?.enable ?? false;
 }
 
-function isValidLocale(locale: string) {
-	try {
-		return Intl.getCanonicalLocales(locale).length > 0;
-	} catch (e) {
-		return false;
-	}
-}
-
 function getAppRouterSupportedLocales() {
 	const config = getHeadstartWPConfig();
 
@@ -41,6 +33,12 @@ function getAppRouterSupportedLocales() {
 		supportedLocales: [...new Set(locales)],
 		localeDetection,
 	};
+}
+
+function isValidLocale(locale: string) {
+	const { supportedLocales } = getAppRouterSupportedLocales();
+
+	return supportedLocales.includes(locale);
 }
 
 /**
@@ -62,7 +60,7 @@ export function getAppRouterLocale(request: NextRequest): [string, string] | und
 
 	// if there's a locale in the URL and it's a supported or valid locale, use it
 	const urlLocale = request.nextUrl.pathname.split('/')[1];
-	if (supportedLocales.includes(urlLocale) || isValidLocale(urlLocale)) {
+	if (isValidLocale(urlLocale)) {
 		return [defaultLocale, urlLocale];
 	}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes [#844](https://github.com/10up/headstartwp/issues/844)

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Install Polylang
- And English and at least 1 other language, and set English to the default language
- Create an English page
- View the English page

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fixed `isValidLocale` function to validate against the configuration
> Added - New test condition for technically valid, but unsupported locale

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
