### PR TITLE
fix: forwardBlockAttributes vs blockAttributes

### DIFF
--- a/.changeset/heavy-bikes-join.md
+++ b/.changeset/heavy-bikes-join.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": patch
+---
+
+Fix: only run parseBlockAttribute when forwardBlockAttribute is set for nodes that represent wp blocks

--- a/packages/core/src/dom/parseBlockAttributes.ts
+++ b/packages/core/src/dom/parseBlockAttributes.ts
@@ -53,6 +53,20 @@ export type ParsedBlock<T extends IDataWPBlock = IDataWPBlock> = {
 };
 
 /**
+ * Checks whether the node is a WordPress block
+ *
+ * @param node DomNode
+ *
+ * @returns
+ */
+export function isWordPressBlock(node: Element) {
+	return (
+		typeof node.attribs['data-wp-block-name'] !== 'undefined' &&
+		typeof node.attribs['data-wp-block'] !== 'undefined'
+	);
+}
+
+/**
  * Returns the block name and attributes
  *
  * @param node DomNode
@@ -64,10 +78,7 @@ export function parseBlockAttributes(node?: Element): ParsedBlock {
 		throw new FrameworkError('You are calling `parseBlockAttributes` on a undefined node');
 	}
 
-	if (
-		typeof node.attribs['data-wp-block-name'] === 'undefined' &&
-		typeof node.attribs['data-wp-block'] === 'undefined'
-	) {
+	if (!isWordPressBlock(node)) {
 		warn(
 			'[parseBlockAttributes] You are using the `parseBlockAttributes` hook in a node that is not a block.',
 		);

--- a/packages/core/src/react/components/BaseBlocksRenderer.tsx
+++ b/packages/core/src/react/components/BaseBlocksRenderer.tsx
@@ -7,7 +7,12 @@ import { HeadlessConfig } from '../../types';
 import { warn } from '../../utils';
 import { IBlockAttributes } from '../blocks/types';
 import { getInlineStyles } from '../blocks/utils';
-import { IDataWPBlock, parseBlockAttributes, ParsedBlock } from '../../dom/parseBlockAttributes';
+import {
+	IDataWPBlock,
+	isWordPressBlock,
+	parseBlockAttributes,
+	ParsedBlock,
+} from '../../dom/parseBlockAttributes';
 
 const { default: parse, domToReact } = HtmlReactParser;
 
@@ -243,7 +248,7 @@ export function BaseBlocksRenderer({
 						style: style || undefined,
 					};
 
-					if (forwardBlockAttributes) {
+					if (forwardBlockAttributes && isWordPressBlock(domNode as Element)) {
 						const { attributes, name, className } = parseBlockAttributes(
 							domNode as Element,
 						);

--- a/packages/core/src/react/components/__tests__/BlocksRenderer.tsx
+++ b/packages/core/src/react/components/__tests__/BlocksRenderer.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { DOMNode, domToReact, Element } from 'html-react-parser';
 import React, { ReactElement } from 'react';
 import { isAnchorTag, isBlockByName } from '../../../dom';
@@ -240,6 +240,21 @@ describe('BlocksRenderer', () => {
 		);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('does not forward blockProps to the component for nodes that are not wp blocks', () => {
+		const DivToP = ({ block }: BlockProps<{ blockAttribute: string }>) => {
+			return <p data-testid="block-no-props">{JSON.stringify(block)}</p>;
+		};
+
+		render(
+			<BlocksRenderer html={`<div class="my-class""></div>`} forwardBlockAttributes>
+				<DivToP tagName="div" classList="my-class" />
+			</BlocksRenderer>,
+		);
+
+		const node = screen.getByTestId('block-no-props');
+		expect(node.textContent).toBe('');
 	});
 
 	it('forward context to the component', () => {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #848 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
