### PR TITLE
fix: use normal import for XSS

### DIFF
--- a/.changeset/hungry-mangos-repeat.md
+++ b/.changeset/hungry-mangos-repeat.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": minor
+---
+
+Fix: xss import issue

--- a/package-lock.json
+++ b/package-lock.json
@@ -17831,7 +17831,7 @@
     },
     "packages/core": {
       "name": "@headstartwp/core",
-      "version": "1.5.0-next.5",
+      "version": "1.5.0-next.6",
       "license": "MIT",
       "dependencies": {
         "@justinribeiro/lite-youtube": "^1.3.1",
@@ -17903,11 +17903,11 @@
     },
     "packages/next": {
       "name": "@headstartwp/next",
-      "version": "1.5.0-next.6",
+      "version": "1.5.0-next.7",
       "license": "MIT",
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.5.4",
-        "@headstartwp/core": "^1.5.0-next.5",
+        "@headstartwp/core": "^1.5.0-next.6",
         "@isaacs/ttlcache": "^1.4.1",
         "deepmerge": "^4.3.1",
         "loader-utils": "^3.2.0",
@@ -18017,8 +18017,8 @@
       "name": "@headstartwp/vite-react-test",
       "version": "0.0.0",
       "dependencies": {
-        "@headstartwp/core": "^1.5.0-next.5",
-        "@headstartwp/next": "^1.5.0-next.6",
+        "@headstartwp/core": "^1.5.0-next.6",
+        "@headstartwp/next": "^1.5.0-next.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -18188,8 +18188,8 @@
       "version": "0.2.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@headstartwp/core": "^1.5.0-next.5",
-        "@headstartwp/next": "^1.5.0-next.6",
+        "@headstartwp/core": "^1.5.0-next.6",
+        "@headstartwp/next": "^1.5.0-next.7",
         "@linaria/core": "^6.2.0",
         "@linaria/react": "^6.2.1",
         "clsx": "^1.1.1",
@@ -18228,8 +18228,8 @@
       "version": "0.2.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@headstartwp/core": "^1.5.0-next.5",
-        "@headstartwp/next": "^1.5.0-next.6",
+        "@headstartwp/core": "^1.5.0-next.6",
+        "@headstartwp/next": "^1.5.0-next.7",
         "@linaria/core": "^6.2.0",
         "@linaria/react": "^6.2.1",
         "clsx": "^1.1.1",
@@ -18256,8 +18256,8 @@
       "name": "@10up/wp-multisite-nextjs-app",
       "version": "0.1.0",
       "dependencies": {
-        "@headstartwp/core": "^1.5.0-next.5",
-        "@headstartwp/next": "^1.5.0-next.6",
+        "@headstartwp/core": "^1.5.0-next.6",
+        "@headstartwp/next": "^1.5.0-next.7",
         "next": "^14.2.5",
         "react": "^18",
         "react-dom": "^18"
@@ -18311,8 +18311,8 @@
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@10up/next-redis-cache-provider": "^1.0.0",
-        "@headstartwp/core": "^1.5.0-next.5",
-        "@headstartwp/next": "^1.5.0-next.6",
+        "@headstartwp/core": "^1.5.0-next.6",
+        "@headstartwp/next": "^1.5.0-next.7",
         "@linaria/core": "^6.2.0",
         "@linaria/react": "^6.2.1",
         "clsx": "^1.1.1",
@@ -18342,8 +18342,8 @@
       "name": "@10up/wp-nextjs-app",
       "version": "0.1.0",
       "dependencies": {
-        "@headstartwp/core": "^1.5.0-next.5",
-        "@headstartwp/next": "^1.5.0-next.6",
+        "@headstartwp/core": "^1.5.0-next.6",
+        "@headstartwp/next": "^1.5.0-next.7",
         "next": "^14.2.5",
         "react": "^18",
         "react-dom": "^18"
@@ -18406,8 +18406,8 @@
       "name": "@10up/wp-polylang-nextjs-app",
       "version": "0.1.0",
       "dependencies": {
-        "@headstartwp/core": "^1.5.0-next.5",
-        "@headstartwp/next": "^1.5.0-next.6",
+        "@headstartwp/core": "^1.5.0-next.6",
+        "@headstartwp/next": "^1.5.0-next.7",
         "next": "^14.2.5",
         "react": "^18",
         "react-dom": "^18"

--- a/packages/core/src/dom/wpKsesPost.ts
+++ b/packages/core/src/dom/wpKsesPost.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-param-reassign, @typescript-eslint/no-use-before-define */
-import * as xss from 'xss';
+import sanitize from 'xss';
 import type { IWhiteList, IFilterXSSOptions } from 'xss';
-import { isHrefValueClean, linkingSVGElements, svgAllowList, svgHtmlAllowList } from './svg';
 
-const { default: sanitize } = xss;
+import { isHrefValueClean, linkingSVGElements, svgAllowList, svgHtmlAllowList } from './svg';
 
 interface IWpKsesPostOptions extends IFilterXSSOptions {
 	svg?: boolean;


### PR DESCRIPTION
### Description of the Change

The current behaviour for importing XSS into `wpKsesPost` is not working fine within some environments. Especially this has been blowing up within Storybook 

![image](https://github.com/user-attachments/assets/2c8ca39b-f11c-4289-92f3-462c208182ed)

### How to test the Change

Run tests and test within any of the examples. This should just keep working and sanitizing output.

### Changelog Entry

> Fixed - Import for XSS within `wpKsesPost` to ensure it works correctly across more strict environments.

### Checklist:
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [X] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [X] All new and existing tests pass.
