### PR TITLE
Fix Block Processor for Multibyte Processing and Synced Patterns

### DIFF
--- a/.changeset/happy-radios-move.md
+++ b/.changeset/happy-radios-move.md
@@ -1,0 +1,7 @@
+---
+"@headstartwp/headstartwp": patch
+---
+
+Added - Improved tests for the Gutenberg block attribute processing
+Fixed - Gutenberg post content block attribute processing for Synced Patterns and support for multibyte characters.
+

--- a/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
+++ b/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
@@ -8,7 +8,10 @@
 namespace HeadlessWP\Integrations;
 
 use DOMDocument;
+use DOMElement;
 use Exception;
+use WP_Block;
+use WP_HTML_Tag_Processor;
 
 /**
  * The Gutenberg integration class
@@ -22,31 +25,76 @@ class Gutenberg {
 	}
 
 	/**
+	 * Check if the current block will bypass block attribute processing
+	 *
+	 * @param string   $block_name     The block name
+	 * @param WP_Block $block_instance The block instance
+	 *
+	 * @return bool
+	 */
+	protected function bypass_block_attributes( string $block_name, WP_Block $block_instance ): bool {
+		$is_synced_pattern = 'core/block' === $block_name;
+
+		/**
+		 * Filter whether to bypass adding block attributes to the current blocks HTML
+		 *  - Defaults to match Synced Pattern (core/block) blocks
+		 *
+		 * @param bool     $is_synced_pattern Whether the block is a synced pattern block
+		 * @param string   $block_name        The blocks name
+		 * @param WP_Block $block_instance    The blocks instance
+		 */
+		return apply_filters( 'tenup_headless_wp_render_block_bypass_block_attributes', $is_synced_pattern, $block_name, $block_instance );
+	}
+
+	/**
+	 * Process the block with the DOMDocument api
+	 *
+	 * @param string   $html                   The block Markup
+	 * @param string   $block_name             The name of the block
+	 * @param string   $block_attrs_serialized The serialized block attributes
+	 * @param array    $block                  The block array
+	 * @param WP_Block $block_instance         The block instance
+	 *
+	 * @return string The processed html
+	 */
+	public function process_block_with_dom_document_api( $html, $block_name, $block_attrs_serialized, $block, $block_instance ) {
+		try {
+			libxml_use_internal_errors( true );
+
+			return $this->bypass_block_attributes( $block_name, $block_instance )
+				? $this->process_dom_document_bypassed_block( $html )
+				: $this->process_dom_document_block( $html, $block_name, $block_attrs_serialized, $block, $block_instance );
+		} catch ( Exception $e ) {
+			return $html;
+		}
+	}
+
+	/**
 	 * Process the block with the WP_HTML_Tag_Processor
 	 *
-	 * @param string    $html The Block's Markup
-	 * @param string    $block_name The name of the block
-	 * @param string    $block_attrs_serialized The serialized block attributes
-	 * @param array     $block The block's array
-	 * @param \WP_Block $block_instance The block instance
+	 * @param string   $html                   The block markup
+	 * @param string   $block_name             The block name
+	 * @param string   $block_attrs_serialized The serialized block attributes
+	 * @param array    $block                  The block schema
+	 * @param WP_Block $block_instance         The block instance
 	 *
 	 * @return string The processed html
 	 */
 	public function process_block_with_html_tag_api( $html, $block_name, $block_attrs_serialized, $block, $block_instance ) {
 		try {
-			$doc = new \WP_HTML_Tag_Processor( $html );
+			$doc = new WP_HTML_Tag_Processor( $html );
 
-			if ( $doc->next_tag() ) {
+			if ( ! $this->bypass_block_attributes( $block_name, $block_instance ) && $doc->next_tag() ) {
 				$doc->set_attribute( 'data-wp-block-name', $block_name );
 				$doc->set_attribute( 'data-wp-block', $block_attrs_serialized );
 
 				/**
-				 * Filter the block's before rendering
+				 * Filter the block before rendering
 				 *
-				 * @param \WP_HTML_Tag_Processor $doc
-				 * @param string $html The original block markup
-				 * @param array $block The Block's schema
-				 * @param \WP_Block $block_instance The block's instance
+				 * @param WP_HTML_Tag_Processor $doc
+				 * @param string                $html           The block markup
+				 * @param array                 $block          The block schema
+				 * @param WP_Block              $block_instance The block instance
 				 */
 				$doc = apply_filters( 'tenup_headless_wp_render_html_tag_processor_block_markup', $doc, $html, $block, $block_instance );
 
@@ -60,59 +108,106 @@ class Gutenberg {
 	}
 
 	/**
-	 * Process the block with the DOMDocument api
+	 * Process Standard blocks into output HTML
 	 *
-	 * @param string    $html The Block's Markup
-	 * @param string    $block_name The name of the block
-	 * @param string    $block_attrs_serialized The serialized block attributes
-	 * @param array     $block The block's array
-	 * @param \WP_Block $block_instance The block instance
+	 * @param string   $html                  The block markup
+	 * @param string   $block_name            The block name
+	 * @param string   $serialized_attributes Serialized attributes
+	 * @param array    $block                 The block array
+	 * @param WP_Block $block_instance        The block instance
 	 *
-	 * @return string The processed html
+	 * @return string
 	 */
-	public function process_block_with_dom_document_api( $html, $block_name, $block_attrs_serialized, $block, $block_instance ) {
-		try {
-			libxml_use_internal_errors( true );
-			$doc = new DomDocument( '1.0', 'UTF-8' );
-			$doc->loadHTML( htmlspecialchars_decode( htmlentities( $html ) ), LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED );
+	public function process_dom_document_block(
+		string $html,
+		string $block_name,
+		string $serialized_attributes,
+		array $block,
+		WP_Block $block_instance
+	): string {
+		$document = $this->read_decoded_dom_document( $html );
 
-			$root_node = $doc->documentElement; // phpcs:ignore
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$root_node = $document->documentElement;
 
-			if ( is_null( $root_node ) ) {
-				return $html;
-			}
+		$attrs        = $document->createAttribute( 'data-wp-block' );
+		$attrs->value = $serialized_attributes;
 
-			$attrs        = $doc->createAttribute( 'data-wp-block' );
-			$attrs->value = $block_attrs_serialized;
+		$block_name_obj        = $document->createAttribute( 'data-wp-block-name' );
+		$block_name_obj->value = $block_name;
 
-			$block_name_obj        = $doc->createAttribute( 'data-wp-block-name' );
-			$block_name_obj->value = $block_name;
+		$root_node->appendChild( $attrs );
+		$root_node->appendChild( $block_name_obj );
 
-			$root_node->appendChild( $attrs );
-			$root_node->appendChild( $block_name_obj );
+		/**
+		 * Filter the block's DOMElement before rendering
+		 *
+		 * @param DOMElement $root_node      Root node of the DOM document
+		 * @param string     $html           The original block markup
+		 * @param array      $block          The block schema
+		 * @param WP_Block   $block_instance The block instance
+		 */
+		$root_node = apply_filters( 'tenup_headless_wp_render_block_markup', $root_node, $html, $block, $block_instance );
 
-			/**
-			 * Filter the block's DOMElement before rendering
-			 *
-			 * @param \DOMElement $root_node
-			 * @param string $html The original block markup
-			 * @param array $block The Block's schema
-			 * @param \WP_Block $block_instance The block's instance
-			 */
-			$root_node = apply_filters( 'tenup_headless_wp_render_block_markup', $root_node, $html, $block, $block_instance );
-
-			return $doc->saveHTML();
-		} catch ( Exception $e ) {
-			return $html;
-		}
+		return $document->saveHTML();
 	}
 
 	/**
-	 * Filter rendered blocks to include a data-wp-blocks attribute with block's attrs
+	 * Process block as direct, multiple HTML nodes without adding block attributes
+	 *  - Useful for Synced Block Patterns which return a set of already processed blocks with attributes
 	 *
-	 * @param string    $html Rendered block content.
-	 * @param array     $block Block data.
-	 * @param \WP_Block $block_instance The block's instance
+	 * @param string $html The block markup
+	 *
+	 * @return string
+	 */
+	public function process_dom_document_bypassed_block( string $html ): string {
+		$document  = $this->read_decoded_dom_document( "<body>{$html}</body>" );
+		$body      = $document->getElementsByTagName( 'body' )->item( 0 );
+		$node_html = [];
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		foreach ( $body->childNodes as $child ) {
+			$block = new DOMDocument();
+			$block->appendChild( $block->importNode( $child, true ) );
+
+			$child_html   = $block->saveHTML();
+			$process_html = is_string( $child_html ) ? trim( $child_html ) : '';
+
+			if ( ! empty( $process_html ) ) {
+				$node_html[] = $process_html;
+			}
+		}
+
+		return implode( '', $node_html );
+	}
+
+	/**
+	 * Read an HTML Entity Decoded DOM Document which allows multi-byte characters
+	 *
+	 * @param string $html HTML markup to process
+	 *
+	 * @throws Exception Empty DOM exception
+	 *
+	 * @return DOMDocument
+	 */
+	protected function read_decoded_dom_document( string $html ) {
+		$document = new DomDocument( '1.0', 'UTF-8' );
+		$document->loadHTML( htmlspecialchars_decode( htmlentities( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) ) ), LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED );
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( null === $document->documentElement ) {
+			throw new Exception( 'Empty DOM document, fallback to use provided HTML.' );
+		}
+
+		return $document;
+	}
+
+	/**
+	 * Filter rendered blocks to include data-wp-blocks and data-wp-block-name attributes within the block attributes
+	 *
+	 * @param string   $html           Rendered block content
+	 * @param array    $block          The block schema
+	 * @param WP_Block $block_instance The block instance
 	 *
 	 * @return string
 	 */
@@ -129,21 +224,21 @@ class Gutenberg {
 		$block_attrs = $block_instance->attributes;
 
 		/**
-		 * Filter's out the block's attributes before serializing in the block markup.
+		 * Filter out any of the block attributes before serializing in the block markup
 		 *
-		 * @param array $attrs The Block's Attributes
-		 * @param array $block The Block's schema
-		 * @param \WP_Block $block_instance The block's instance
+		 * @param array    $attrs          The block attributes
+		 * @param array    $block          The block schema
+		 * @param WP_Block $block_instance The block instance
 		 */
 		$block_attrs = apply_filters( 'tenup_headless_wp_render_block_attrs', $block_attrs, $block, $block_instance );
 
 		/**
-		 * Filter's out the block's attributes after serialization
+		 * Filter out the block attributes after serialization
 		 *
-		 * @param string $encoded_attrs The serialized block's Attributes
-		 * @param array $attrs The Block's Attributes
-		 * @param array $block The Block's schema
-		 * @param \WP_Block $block_instance The block's instance
+		 * @param string   $encoded_attrs  The serialized block attributes
+		 * @param array    $attrs          The block attributes
+		 * @param array    $block          The block schema
+		 * @param WP_Block $block_instance The block instance
 		 */
 		$block_attrs_serialized = apply_filters(
 			'tenup_headless_wp_render_blocks_attrs_serialized',
@@ -158,11 +253,11 @@ class Gutenberg {
 		/**
 		 * Filter for enabling the use of the new HTML_Tag_Processor API
 		 *
-		 * @param boolean $enable Whether enable the new api. Defaults to false
+		 * @param boolean $enable Whether enable the new HTML Tag API, defaults to off/false
 		 */
-		$parser_api = apply_filters( 'tenup_headless_wp_render_block_use_tag_processor', false );
+		$use_html_tag_api = apply_filters( 'tenup_headless_wp_render_block_use_tag_processor', false );
 
-		if ( class_exists( '\WP_HTML_Tag_Processor' ) && $parser_api ) {
+		if ( class_exists( WP_HTML_Tag_Processor::class ) && $use_html_tag_api ) {
 			return $this->process_block_with_html_tag_api(
 				$html,
 				$block_name,

--- a/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
+++ b/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
@@ -59,8 +59,6 @@ class Gutenberg {
 	 */
 	public function process_block_with_dom_document_api( $html, $block_name, $block_attrs_serialized, $block, $block_instance ) {
 		try {
-			libxml_use_internal_errors( true );
-
 			return $this->bypass_block_attributes( $block_name, $block_instance )
 				? $this->process_dom_document_bypassed_block( $html )
 				: $this->process_dom_document_block( $html, $block_name, $block_attrs_serialized, $block, $block_instance );
@@ -125,7 +123,7 @@ class Gutenberg {
 		array $block,
 		WP_Block $block_instance
 	): string {
-		$document = $this->read_decoded_dom_document( $html );
+		$document = $this->read_converted_dom_document( $html );
 
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$root_node = $document->documentElement;
@@ -161,13 +159,13 @@ class Gutenberg {
 	 * @return string
 	 */
 	public function process_dom_document_bypassed_block( string $html ): string {
-		$document  = $this->read_decoded_dom_document( "<body>{$html}</body>" );
+		$document  = $this->read_converted_dom_document( "<body>{$html}</body>" );
 		$body      = $document->getElementsByTagName( 'body' )->item( 0 );
 		$node_html = [];
 
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		foreach ( $body->childNodes as $child ) {
-			$block = new DOMDocument();
+			$block = new DOMDocument( '1.0', 'UTF-8' );
 			$block->appendChild( $block->importNode( $child, true ) );
 
 			$child_html   = $block->saveHTML();
@@ -190,9 +188,13 @@ class Gutenberg {
 	 *
 	 * @return DOMDocument
 	 */
-	protected function read_decoded_dom_document( string $html ) {
-		$document = new DomDocument( '1.0', 'UTF-8' );
-		$document->loadHTML( htmlspecialchars_decode( htmlentities( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) ) ), LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED );
+	protected function read_converted_dom_document( string $html ) {
+		$converted_html = htmlspecialchars_decode( htmlentities( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) ) );
+		$document       = new DomDocument( '1.0', 'UTF-8' );
+
+		libxml_use_internal_errors( true );
+		$document->loadHTML( $converted_html, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED );
+		libxml_clear_errors();
 
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		if ( null === $document->documentElement ) {

--- a/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
+++ b/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
@@ -8,29 +8,48 @@
 namespace HeadlessWP\Tests;
 
 use HeadlessWP\Integrations\Gutenberg;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 use WP_Block;
+use WP_Error;
 use WP_HTML_Tag_Processor;
+use WP_UnitTestCase;
 
 /**
  * Covers the test for the Gutenberg integration
  */
-class TestGutenbergIntegration extends TestCase {
+class TestGutenbergIntegration extends WP_UnitTestCase {
 
 	/**
-	 * Data for render test processing
+	 * The Gutenberg parser
+	 *
+	 * @var Gutenberg
+	 */
+	public Gutenberg $parser;
+
+	/**
+	 * Sets up the Test class
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		$this->parser = new Gutenberg();
+	}
+
+	/**
+	 * Data for render_block test processing
 	 *
 	 * @return array[]
 	 */
-	public function render_data(): array {
+	public function render_block_data(): array {
 		return [
 			'Single Tag Markup'                   => [
-				<<<MARKUP
-				<!-- wp:heading {"level":3} -->
-				<h3 id="hello-world">Hello world</h3>
-				<!-- /wp:heading -->
-				MARKUP,
+				$this->core_render_block_from_markup(
+					<<<MARKUP
+					<!-- wp:heading {"level":3} -->
+					<h3 id="hello-world">Hello world</h3>
+					<!-- /wp:heading -->
+					MARKUP
+				),
 				[
 					[
 						'attributes' => [
@@ -43,18 +62,20 @@ class TestGutenbergIntegration extends TestCase {
 				],
 			],
 			'Inner Blocks Markup'                 => [
-				<<<MARKUP
-				<!-- wp:media-text {"mediaId":28,"mediaLink":"http://localhost:8888/blocks-test/screenshot-2023-06-16-at-11-09-21/","mediaType":"image"} -->
-				<div class="wp-block-media-text alignwide is-stacked-on-mobile">
-					<figure class="wp-block-media-text__media"><img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28 size-full"/></figure>
-					<div class="wp-block-media-text__content">
-					<!-- wp:paragraph {"placeholder":"Content…"} -->
-						<p>Text</p>
-					<!-- /wp:paragraph -->
+				$this->core_render_block_from_markup(
+					<<<MARKUP
+					<!-- wp:media-text {"mediaId":28,"mediaLink":"http://localhost:8888/blocks-test/screenshot-2023-06-16-at-11-09-21/","mediaType":"image"} -->
+					<div class="wp-block-media-text alignwide is-stacked-on-mobile">
+						<figure class="wp-block-media-text__media"><img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28 size-full"/></figure>
+						<div class="wp-block-media-text__content">
+						<!-- wp:paragraph {"placeholder":"Content…"} -->
+							<p>Text</p>
+						<!-- /wp:paragraph -->
+						</div>
 					</div>
-				</div>
-				<!-- /wp:media-text -->
-				MARKUP,
+					<!-- /wp:media-text -->
+					MARKUP
+				),
 				[
 					[
 						'attributes' => [
@@ -69,11 +90,13 @@ class TestGutenbergIntegration extends TestCase {
 				],
 			],
 			'Image Block Markup'                  => [
-				<<<MARKUP
-				<!-- wp:image {"id":28,"sizeSlug":"large","linkDestination":"none"} -->
-				<figure class="wp-block-image size-large"><img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28"/></figure>
-				<!-- /wp:image -->
-				MARKUP,
+				$this->core_render_block_from_markup(
+					<<<MARKUP
+					<!-- wp:image {"id":28,"sizeSlug":"large","linkDestination":"none"} -->
+					<figure class="wp-block-image size-large"><img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28"/></figure>
+					<!-- /wp:image -->
+					MARKUP
+				),
 				[
 					[
 						'attributes' => [
@@ -87,99 +110,201 @@ class TestGutenbergIntegration extends TestCase {
 					],
 				],
 			],
-			'Synced Pattern | Multi-Block Markup' => [
-				<<<MARKUP
-				<!-- wp:heading -->
-				<h2 id="heading-anchor">Main Content Heading</h3>
-				<!-- /wp:heading -->
-				<!-- wp:heading {"level":3} -->
-				<h3>Content Sub-heading</h3>
-				<!-- /wp:heading -->
-				<!-- wp:paragraph -->
-				<p>Hello world</p>
-				<!-- /wp:paragraph -->
-				MARKUP,
-				[
-					[
-						'attributes' => [
-							'level' => '2',
-						],
-						'inner_tags' => [],
-						'name'       => 'core/heading',
-						'tag'        => 'h2',
-					],
-					[
-						'attributes' => [
-							'level' => '3',
-						],
-						'inner_tags' => [],
-						'name'       => 'core/heading',
-						'tag'        => 'h3',
-					],
-					[
-						'attributes' => [],
-						'inner_tags' => [],
-						'name'       => 'core/paragraph',
-						'tag'        => 'p',
-					],
-				],
-			],
-
 		];
 	}
 
 	/**
-	 * The Gutenberg parser
-	 *
-	 * @var Gutenberg
-	 */
-	protected $parser;
-
-	/**
-	 * Sets up the Test class
-	 *
-	 * @return void
-	 */
-	public function set_up() {
-		$this->parser = new Gutenberg();
-	}
-
-	/**
-	 * Renders a block from block markup
+	 * Uses WP Core to parse and render a block from block markup
 	 *
 	 * @param string $markup The block markup
 	 * @return array
 	 */
-	protected function render_from_block_markup( string $markup ): array {
+	protected function core_render_block_from_markup( string $markup ): array {
 		$blocks   = parse_blocks( $markup );
 		$block    = $blocks[0];
 		$instance = new WP_Block( $block );
 
 		return [
-			'html'         => apply_filters( 'the_content', $instance->render() ),
+			'html'         => apply_filters( 'the_content', render_block( $block ) ),
 			'parsed_block' => $block,
 			'instance'     => $instance,
 		];
 	}
 
 	/**
-	 * Tests block's standard rendering
-	 *  - Testing the exact order of attributes and spacing of the output HTML is not in the scope of this component
+	 * Tests rendering classic block
+	 * 	- Classic blocks contain raw HTML without attributes
+	 *
+	 * @return void
+	 */
+	public function test_render_classic_block() {
+		$block          = $this->core_render_block_from_markup( '<h1><span style="font-weight: 400;">Introduction</span></h1><span style="font-weight: 400;">If you have read our previous article, </span>' );
+		$enhanced_block = $this->parser->render_block( $block['html'], $block['parsed_block'], $block['instance'] );
+
+		$result = <<<RESULT
+		<h1><span style="font-weight: 400;">Introduction</span></h1>
+<p><span style="font-weight: 400;">If you have read our previous article, </span></p>
+RESULT;
+
+		$this->assertEquals(
+			trim( $enhanced_block ),
+			trim( $result )
+		);
+	}
+
+	/**
+	 * Tests rendering classic block with the HTML tag api
+	 *
+	 * @return void
+	 */
+	public function test_render_classic_block_html_tag_api() {
+		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+
+		$this->test_render_classic_block();
+
+		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+	}
+
+	/**
+	 * Tests block's rendering with newer tag processor api
+	 *  - Wrapper to run test_render with the HTML Tag API processor enabled
+	 *
+	 * @dataProvider render_block_data
+	 *
+	 * @param array $incoming Incoming HTML
+	 * @param array $block_structure Expected block name and attributes
+	 *
+	 * @return void
+	 */
+	public function test_render_dom_document_api( array $incoming, array $block_structure ) {
+		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_false' );
+
+		$this->validate_processed_blocks(
+			$this->parser->render_block( $incoming['html'], $incoming['parsed_block'], $incoming['instance'] ),
+			$block_structure,
+			'DOM Document'
+		);
+
+		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_false' );
+	}
+
+	/**
+	 * Tests block's rendering with newer tag processor api
+	 *  - Wrapper to run test_render with the HTML Tag API processor enabled
+	 *
+	 * @dataProvider render_block_data
+	 *
+	 * @param array $incoming Incoming HTML
+	 * @param array $block_structure Expected block name and attributes
+	 *
+	 * @return void
+	 */
+	public function test_render_html_tag_api( array $incoming, array $block_structure ) {
+		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+
+		$this->validate_processed_blocks(
+			$this->parser->render_block( $incoming['html'], $incoming['parsed_block'], $incoming['instance'] ),
+			$block_structure,
+			'HTML Tag API'
+		);
+
+		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+	}
+
+	/**
+	 * Tests block's rendering Synced Patterns which use another post to store the patterns content
+	 * 	- Run separate to hook the Parser filter on all render_block processing, required for nested blocks
+	 *
+	 * @return void
+	 */
+	public function test_render_synced_patterns() {
+		$pattern_post_id = self::factory()->post->create(
+			[
+				'post_author'  => 1,
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Synced Pattern Test',
+				'post_content' =>
+					<<<MARKUP
+					<!-- wp:heading -->
+					<h2 id="heading-anchor">Main Content Heading</h2>
+					<!-- /wp:heading -->
+					<!-- wp:heading {"level":3} -->
+					<h3>Content Sub-heading</h3>
+					<!-- /wp:heading -->
+					<!-- wp:paragraph -->
+					<p>Hello world</p>
+					<!-- /wp:paragraph -->
+					MARKUP
+			]
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $pattern_post_id, 'Could not create Synced Pattern post' );
+
+		add_filter( 'render_block', [ $this->parser, 'render_block' ], 10, 3 );
+
+		$block = $this->core_render_block_from_markup(
+			<<<MARKUP
+			<!-- wp:block {"ref": {$pattern_post_id}} -->
+			MARKUP
+		);
+
+		$block_structure = [
+			[
+				'attributes' => [
+					'level' => '2',
+				],
+				'inner_tags' => [],
+				'name'       => 'core/heading',
+				'tag'        => 'h2',
+			],
+			[
+				'attributes' => [
+					'level' => '3',
+				],
+				'inner_tags' => [],
+				'name'       => 'core/heading',
+				'tag'        => 'h3',
+			],
+			[
+				'attributes' => [],
+				'inner_tags' => [],
+				'name'       => 'core/paragraph',
+				'tag'        => 'p',
+			],
+		];
+
+		$this->validate_processed_blocks( $block['html'], $block_structure, 'DOM Document Synced Pattern' );
+
+		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+
+		$html_api_block = $this->core_render_block_from_markup(
+			<<<MARKUP
+			<!-- wp:block {"ref": {$pattern_post_id}} -->
+			MARKUP
+		);
+
+		$this->validate_processed_blocks( $html_api_block['html'], $block_structure, 'HTML Tag API Synced Pattern' );
+
+		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+
+
+		remove_filter( 'render_block', [ $this->parser, 'render_block' ], 10 );
+	}
+
+	/**
+	 * Validate the processed blocks output
+	 *  - Testing the exact order of attributes and spacing of the output HTML is not in the scope of this component, and creates fragile tests
 	 *  - Tests correct tags and attributes are created over exact HTML output
 	 *
-	 * @dataProvider render_data
-	 *
-	 * @param string $incoming Incoming HTML
+	 * @param string $processed_blocks Incoming HTML
 	 * @param array  $expected_block_structure Expected block name and attributes
 	 * @param string $process_name Assertion message process name
 	 *
 	 * @return void
 	 */
-	public function test_render( string $incoming, array $expected_block_structure, string $process_name = 'DOM Document' ) {
-		$block          = $this->render_from_block_markup( trim( $incoming ) );
-		$enhanced_block = $this->parser->render_block( $block['html'], $block['parsed_block'], $block['instance'] );
-
-		$tag_processor = new WP_HTML_Tag_Processor( $enhanced_block );
+	public function validate_processed_blocks( string $processed_blocks, array $expected_block_structure, string $process_name ) {
+		$tag_processor = new WP_HTML_Tag_Processor( $processed_blocks );
 
 		foreach ( $expected_block_structure as $expected_block ) {
 			[ 'attributes' => $attributes, 'inner_tags' => $inner_tags, 'name' => $name, 'tag' => $tag ] = $expected_block;
@@ -205,57 +330,5 @@ class TestGutenbergIntegration extends TestCase {
 
 		$tag_processor->next_tag( [ 'tag_closers' => 'skip' ] );
 		$this->assertEmpty( $tag_processor->get_tag(), "{$process_name} | No more tags expected." );
-	}
-
-	/**
-	 * Tests block's rendering with newer tag processor api
-	 *  - Wrapper to run test_render with the HTML Tag API processor enabled
-	 *
-	 * @dataProvider render_data
-	 *
-	 * @param string $incoming Incoming HTML
-	 * @param array  $block_structure Expected block name and attributes
-	 *
-	 * @return void
-	 */
-	public function test_render_tag_api( string $incoming, array $block_structure ) {
-		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
-
-		$this->test_render( $incoming, $block_structure, 'HTML Tag API' );
-
-		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
-	}
-
-	/**
-	 * Tests rendering classic block
-	 *
-	 * @return void
-	 */
-	public function test_render_classic_block() {
-		$block          = $this->render_from_block_markup( '<h1><span style="font-weight: 400;">Introduction</span></h1><span style="font-weight: 400;">If you have read our previous article, </span>' );
-		$enhanced_block = $this->parser->render_block( $block['html'], $block['parsed_block'], $block['instance'] );
-
-		$result = <<<RESULT
-		<h1><span style="font-weight: 400;">Introduction</span></h1>
-<p><span style="font-weight: 400;">If you have read our previous article, </span></p>
-RESULT;
-
-		$this->assertEquals(
-			trim( $enhanced_block ),
-			trim( $result )
-		);
-	}
-
-	/**
-	 * Tests rendering classic block with tag api
-	 *
-	 * @return void
-	 */
-	public function test_render_classic_block_tag_api() {
-		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
-
-		$this->test_render_classic_block();
-
-		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
 	}
 }

--- a/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
+++ b/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
@@ -42,7 +42,7 @@ class TestGutenbergIntegration extends WP_UnitTestCase {
 	 */
 	public function render_block_data(): array {
 		return [
-			'Single Tag Markup'                   => [
+			'Single Tag Markup'   => [
 				$this->core_render_block_from_markup(
 					<<<MARKUP
 					<!-- wp:heading {"level":3} -->
@@ -61,7 +61,7 @@ class TestGutenbergIntegration extends WP_UnitTestCase {
 					],
 				],
 			],
-			'Inner Blocks Markup'                 => [
+			'Inner Blocks Markup' => [
 				$this->core_render_block_from_markup(
 					<<<MARKUP
 					<!-- wp:media-text {"mediaId":28,"mediaLink":"http://localhost:8888/blocks-test/screenshot-2023-06-16-at-11-09-21/","mediaType":"image"} -->
@@ -89,7 +89,7 @@ class TestGutenbergIntegration extends WP_UnitTestCase {
 					],
 				],
 			],
-			'Image Block Markup'                  => [
+			'Image Block Markup'  => [
 				$this->core_render_block_from_markup(
 					<<<MARKUP
 					<!-- wp:image {"id":28,"sizeSlug":"large","linkDestination":"none"} -->
@@ -133,7 +133,7 @@ class TestGutenbergIntegration extends WP_UnitTestCase {
 
 	/**
 	 * Tests rendering classic block
-	 * 	- Classic blocks contain raw HTML without attributes
+	 *  - Classic blocks contain raw HTML without attributes
 	 *
 	 * @return void
 	 */
@@ -213,7 +213,7 @@ RESULT;
 
 	/**
 	 * Tests block's rendering Synced Patterns which use another post to store the patterns content
-	 * 	- Run separate to hook the Parser filter on all render_block processing, required for nested blocks
+	 *  - Run separate to hook the Parser filter on all render_block processing, required for nested blocks
 	 *
 	 * @return void
 	 */
@@ -235,7 +235,7 @@ RESULT;
 					<!-- wp:paragraph -->
 					<p>Hello world</p>
 					<!-- /wp:paragraph -->
-					MARKUP
+					MARKUP,
 			]
 		);
 
@@ -287,7 +287,6 @@ RESULT;
 		$this->validate_processed_blocks( $html_api_block['html'], $block_structure, 'HTML Tag API Synced Pattern' );
 
 		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
-
 
 		remove_filter( 'render_block', [ $this->parser, 'render_block' ], 10 );
 	}

--- a/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
+++ b/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
@@ -10,10 +10,123 @@ namespace HeadlessWP\Tests;
 use HeadlessWP\Integrations\Gutenberg;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
+use WP_Block;
+use WP_HTML_Tag_Processor;
+
 /**
  * Covers the test for the Gutenberg integration
  */
 class TestGutenbergIntegration extends TestCase {
+
+	/**
+	 * Data for render test processing
+	 *
+	 * @return array[]
+	 */
+	public function render_data(): array {
+		return [
+			'Single Tag Markup'                   => [
+				<<<MARKUP
+				<!-- wp:heading {"level":3} -->
+				<h3 id="hello-world">Hello world</h3>
+				<!-- /wp:heading -->
+				MARKUP,
+				[
+					[
+						'attributes' => [
+							'level' => '3',
+						],
+						'inner_tags' => [],
+						'name'       => 'core/heading',
+						'tag'        => 'h3',
+					],
+				],
+			],
+			'Inner Blocks Markup'                 => [
+				<<<MARKUP
+				<!-- wp:media-text {"mediaId":28,"mediaLink":"http://localhost:8888/blocks-test/screenshot-2023-06-16-at-11-09-21/","mediaType":"image"} -->
+				<div class="wp-block-media-text alignwide is-stacked-on-mobile">
+					<figure class="wp-block-media-text__media"><img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28 size-full"/></figure>
+					<div class="wp-block-media-text__content">
+					<!-- wp:paragraph {"placeholder":"Content…"} -->
+						<p>Text</p>
+					<!-- /wp:paragraph -->
+					</div>
+				</div>
+				<!-- /wp:media-text -->
+				MARKUP,
+				[
+					[
+						'attributes' => [
+							'mediaId'   => '28',
+							'mediaLink' => 'http://localhost:8888/blocks-test/screenshot-2023-06-16-at-11-09-21/',
+							'mediaType' => 'image',
+						],
+						'inner_tags' => [ 'figure', 'img', 'div', 'p' ],
+						'name'       => 'core/media-text',
+						'tag'        => 'div',
+					],
+				],
+			],
+			'Image Block Markup'                  => [
+				<<<MARKUP
+				<!-- wp:image {"id":28,"sizeSlug":"large","linkDestination":"none"} -->
+				<figure class="wp-block-image size-large"><img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28"/></figure>
+				<!-- /wp:image -->
+				MARKUP,
+				[
+					[
+						'attributes' => [
+							'id'              => '28',
+							'linkDestination' => 'none',
+							'sizeSlug'        => 'large',
+						],
+						'inner_tags' => [ 'img' ],
+						'name'       => 'core/image',
+						'tag'        => 'figure',
+					],
+				],
+			],
+			'Synced Pattern | Multi-Block Markup' => [
+				<<<MARKUP
+				<!-- wp:heading -->
+				<h2 id="heading-anchor">Main Content Heading</h3>
+				<!-- /wp:heading -->
+				<!-- wp:heading {"level":3} -->
+				<h3>Content Sub-heading</h3>
+				<!-- /wp:heading -->
+				<!-- wp:paragraph -->
+				<p>Hello world</p>
+				<!-- /wp:paragraph -->
+				MARKUP,
+				[
+					[
+						'attributes' => [
+							'level' => '2',
+						],
+						'inner_tags' => [],
+						'name'       => 'core/heading',
+						'tag'        => 'h2',
+					],
+					[
+						'attributes' => [
+							'level' => '3',
+						],
+						'inner_tags' => [],
+						'name'       => 'core/heading',
+						'tag'        => 'h3',
+					],
+					[
+						'attributes' => [],
+						'inner_tags' => [],
+						'name'       => 'core/paragraph',
+						'tag'        => 'p',
+					],
+				],
+			],
+
+		];
+	}
 
 	/**
 	 * The Gutenberg parser
@@ -37,83 +150,78 @@ class TestGutenbergIntegration extends TestCase {
 	 * @param string $markup The block markup
 	 * @return array
 	 */
-	protected function render_from_block_markup( $markup ) {
-		$blocks = parse_blocks( $markup );
-		$block  = $blocks[0];
+	protected function render_from_block_markup( string $markup ): array {
+		$blocks   = parse_blocks( $markup );
+		$block    = $blocks[0];
+		$instance = new WP_Block( $block );
 
 		return [
-			'html'         => apply_filters( 'the_content', render_block( $block ) ),
+			'html'         => apply_filters( 'the_content', $instance->render() ),
 			'parsed_block' => $block,
-			'instance'     => new \WP_Block( $block ),
+			'instance'     => $instance,
 		];
 	}
 
 	/**
-	 * Tests block's rendering
+	 * Tests block's standard rendering
+	 *  - Testing the exact order of attributes and spacing of the output HTML is not in the scope of this component
+	 *  - Tests correct tags and attributes are created over exact HTML output
+	 *
+	 * @dataProvider render_data
+	 *
+	 * @param string $incoming Incoming HTML
+	 * @param array  $expected_block_structure Expected block name and attributes
+	 * @param string $process_name Assertion message process name
 	 *
 	 * @return void
 	 */
-	public function test_render() {
-		$block          = $this->render_from_block_markup( '<!-- wp:heading {"level":3} --> <h3 id="hello-world">Hello world</h3><!-- /wp:heading -->' );
+	public function test_render( string $incoming, array $expected_block_structure, string $process_name = 'DOM Document' ) {
+		$block          = $this->render_from_block_markup( trim( $incoming ) );
 		$enhanced_block = $this->parser->render_block( $block['html'], $block['parsed_block'], $block['instance'] );
 
-		$this->assertEquals(
-			trim( $enhanced_block ),
-			'<h3 class="wp-block-heading" id="hello-world" data-wp-block=\'{"level":3}\' data-wp-block-name="core/heading">Hello world</h3>'
-		);
+		$tag_processor = new WP_HTML_Tag_Processor( $enhanced_block );
 
-		$markup = <<<MARKUP
-		<!-- wp:image {"id":28,"sizeSlug":"large","linkDestination":"none"} -->
-		<figure class="wp-block-image size-large"><img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28"/></figure>
-		<!-- /wp:image -->
-MARKUP;
+		foreach ( $expected_block_structure as $expected_block ) {
+			[ 'attributes' => $attributes, 'inner_tags' => $inner_tags, 'name' => $name, 'tag' => $tag ] = $expected_block;
 
-		$block          = $this->render_from_block_markup( trim( $markup ) );
-		$enhanced_block = $this->parser->render_block( $block['html'], $block['parsed_block'], $block['instance'] );
+			$this->assertTrue( $tag_processor->next_tag( [ 'tag_closers' => 'skip' ] ), "{$process_name} | Expected next tag {$tag}, none found." );
 
-		$result = <<<MARKUP
-		<figure class="wp-block-image size-large" data-wp-block='{"id":28,"sizeSlug":"large","linkDestination":"none","alt":""}' data-wp-block-name="core/image"><img decoding="async" src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28"></figure>
-MARKUP;
+			$found_tag = strtolower( $tag_processor->get_tag() );
+			$this->assertEquals( $tag, $found_tag, "{$process_name} | Expected tag {$tag}, found {$found_tag}." );
+			$this->assertEquals( $name, $tag_processor->get_attribute( 'data-wp-block-name' ), "{$process_name} | Expected block {$name}." );
 
-		$this->assertEquals(
-			trim( $enhanced_block ),
-			trim( $result )
-		);
+			$parsed_attributes = json_decode( $tag_processor->get_attribute( 'data-wp-block' ), true );
 
-		$markup = <<<MARKUP
-		<!-- wp:media-text {"mediaId":28,"mediaLink":"http://localhost:8888/blocks-test/screenshot-2023-06-16-at-11-09-21/","mediaType":"image"} -->
-		<div class="wp-block-media-text alignwide is-stacked-on-mobile">
-			<figure class="wp-block-media-text__media">
-				<img src="http://localhost:8888/wp-content/uploads/2023/06/Screenshot-2023-06-16-at-11.09.21-1024x725.png" alt="" class="wp-image-28 size-full"/>
-			</figure>
-			<div class="wp-block-media-text__content">
-			<!-- wp:paragraph {"placeholder":"Content…"} -->
-				<p>Text</p>
-			<!-- /wp:paragraph -->
-			</div>
-		</div>
-		<!-- /wp:media-text -->
-MARKUP;
+			foreach ( $attributes as $attribute => $value ) {
+				$this->assertArrayHasKey( $attribute, $parsed_attributes, "{$process_name} | Expected attribute {$attribute}." );
+				$this->assertEquals( $value, $parsed_attributes[ $attribute ], "{$process_name} | Expected attribute '{$attribute}' value of '{$value}'." );
+			}
 
-		$block          = $this->render_from_block_markup( trim( $markup ) );
-		$enhanced_block = $this->parser->render_block( $block['html'], $block['parsed_block'], $block['instance'] );
+			foreach ( $inner_tags as $tag_name ) {
+				$tag_processor->next_tag( [ 'tag_closers' => 'skip' ] );
+				$this->assertEquals( $tag_name, strtolower( $tag_processor->get_tag() ), "{$process_name} | Expected internal tag {$tag_name}." );
+			}
+		}
 
-		$enhanced_block_doc = new \WP_HTML_Tag_Processor( $enhanced_block );
-
-		$this->assertTrue( $enhanced_block_doc->next_tag() );
-		$this->assertEquals( $enhanced_block_doc->get_attribute( 'data-wp-block-name' ), 'core/media-text' );
-		$this->assertArrayHasKey( 'mediaId', json_decode( $enhanced_block_doc->get_attribute( 'data-wp-block' ), true ) );
+		$tag_processor->next_tag( [ 'tag_closers' => 'skip' ] );
+		$this->assertEmpty( $tag_processor->get_tag(), "{$process_name} | No more tags expected." );
 	}
 
 	/**
-	 * Tests block's rendering with tag api
+	 * Tests block's rendering with newer tag processor api
+	 *  - Wrapper to run test_render with the HTML Tag API processor enabled
+	 *
+	 * @dataProvider render_data
+	 *
+	 * @param string $incoming Incoming HTML
+	 * @param array  $block_structure Expected block name and attributes
 	 *
 	 * @return void
 	 */
-	public function test_render_tag_api() {
-		apply_filters( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+	public function test_render_tag_api( string $incoming, array $block_structure ) {
+		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
 
-		$this->test_render();
+		$this->test_render( $incoming, $block_structure, 'HTML Tag API' );
 
 		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
 	}
@@ -144,7 +252,7 @@ RESULT;
 	 * @return void
 	 */
 	public function test_render_classic_block_tag_api() {
-		apply_filters( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
 
 		$this->test_render_classic_block();
 

--- a/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
+++ b/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
@@ -153,6 +153,40 @@ RESULT;
 	}
 
 	/**
+	 * Test to ensure the parser handles both HTML and Multi-byte encodings properly
+	 *
+	 * @return void
+	 */
+	public function test_handle_multi_byte_html_encoding() {
+		[ 'html' => $html, 'parsed_block' => $block, 'instance' => $instance ] =
+			$this->core_render_block_from_markup(
+				<<<MARKUP
+				<!-- wp:paragraph -->
+				<p>The temperature is 23°C ☀️ (sun emoji) and © (copyright symbol). HTML entity for Degrees: &#176;.</p>
+				<!-- /wp:paragraph -->
+				MARKUP
+			);
+		$dom_expected          = <<<RESULT
+			<p data-wp-block='{"dropCap":false}' data-wp-block-name="core/paragraph">The temperature is 23&deg;C &#9728;&#65039; (sun emoji) and &copy; (copyright symbol). HTML entity for Degrees: &deg;.</p>
+			RESULT;
+		$html_tag_api_expected = <<<RESULT
+			<p data-wp-block="{&quot;dropCap&quot;:false}" data-wp-block-name="core/paragraph">The temperature is 23&deg;C &#9728;&#65039; (sun emoji) and &copy; (copyright symbol). HTML entity for Degrees: &deg;.</p>
+			RESULT;
+
+		$dom_output = $this->parser->render_block( $html, $block, $instance );
+
+		$this->assertSame( trim( $dom_expected ), trim( $dom_output ), 'Gutenberg | DOM Document | Test HTML Encoding' );
+
+		add_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+
+		$html_api_output = $this->parser->render_block( $html, $block, $instance );
+
+		remove_filter( 'tenup_headless_wp_render_block_use_tag_processor', '__return_true' );
+
+		$this->assertSame( trim( $html_tag_api_expected ), trim( $html_api_output ), 'Gutenberg | HTML Tag API | Test HTML Encoding' );
+	}
+
+	/**
 	 * Tests rendering classic block with the HTML tag api
 	 *
 	 * @return void


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

A couple issues were identified with HeadstartWP's WordPress plugin side:

1. Attributes on synced block patterns were being overwritten with core/block instead of the correct inner blocks, as well as nesting any block past the first in a Synced pattern underneath the first block. `<h2></h2><h3></h3><p></p>` => `<h2><h3></h3><p></p></h2>`  
2. Could not process multi-byte encoded characters


### How to test the Change

#### Synced Patterns
1. Add a Block Pattern to any page with more than one block in it, ensure the Synced checkbox is enabled.
2. Save the Post and view the page on the REST API to ensure the Synced Pattern in `content.rendered` shows as the correct blocks with correct `data-wp-block-name` and that they are not inappropriately nested.

#### Multibyte Characters

1. Include a block like following on a page:
    ```
    <!-- wp:paragraph -->
    <p>The temperature is 23°C ☀️ (sun emoji) and © (copyright symbol). HTML entity for Degrees: &#176;.</p>
    <!-- /wp:paragraph -->
    ```
2. Ensure the content show properly encoded on the REST API.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Improved tests for the Gutenberg block attribute processing
> Fixed - Gutenberg post content block attribute processing for Synced Patterns and support for multibyte characters. 

### Credits
Props @rleeson 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
