### PR TITLE
fix: mb_convert_enconding deprecation notice for PHP >= 8.2

### DIFF
--- a/.changeset/witty-falcons-repair.md
+++ b/.changeset/witty-falcons-repair.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/headstartwp": patch
+---
+
+Fix deprecation notice for PHP >= 8.2 for the usage of mb_convert_encoding with 'HTML-ENTITIES'

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup npm cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -27,7 +27,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Restore next build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: restore-build-cache
         env:
           cache-name: cache-next-build

--- a/.github/workflows/npm-release-next-version.yml
+++ b/.github/workflows/npm-release-next-version.yml
@@ -27,7 +27,7 @@ jobs:
           [[ ! -f .changeset/pre.json ]] && npx changeset pre enter next || echo 'already in pre mode'
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: actions/cache@v4
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run publish

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup npm cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/wp/headless-wp/.wp-env.json
+++ b/wp/headless-wp/.wp-env.json
@@ -2,17 +2,17 @@
   "plugins": [
     ".",
     "../local-plugin",
-    "https://downloads.wordpress.org/plugin/wordpress-seo.22.1.zip",
-    "https://downloads.wordpress.org/plugin/safe-redirect-manager.2.1.1.zip"
+    "https://downloads.wordpress.org/plugin/wordpress-seo.22.9.zip",
+    "https://downloads.wordpress.org/plugin/safe-redirect-manager.2.2.2.zip"
   ],
   "env": {
     "tests": {
         "plugins": [
           ".",
           "../local-plugin",
-          "https://downloads.wordpress.org/plugin/wordpress-seo.22.1.zip",
-          "https://downloads.wordpress.org/plugin/safe-redirect-manager.2.1.1.zip",
-          "https://downloads.wordpress.org/plugin/polylang.3.5.4.zip"
+          "https://downloads.wordpress.org/plugin/wordpress-seo.22.9.zip",
+          "https://downloads.wordpress.org/plugin/safe-redirect-manager.2.2.2.zip",
+          "https://downloads.wordpress.org/plugin/polylang.3.6.6.zip"
         ]
     }
 }

--- a/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
+++ b/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
@@ -189,7 +189,9 @@ class Gutenberg {
 	 * @return DOMDocument
 	 */
 	protected function read_converted_dom_document( string $html ) {
-		$converted_html = htmlspecialchars_decode( htmlentities( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) ) );
+		// Yes this is cryptic, but the previous way using mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) has been deprecated
+		// @see https://www.drupal.org/project/smart_trim/issues/3342481#comment-14982548
+		$converted_html = mb_encode_numericentity( $html, [ 0x80, 0x10FFFF, 0, ~0 ], 'UTF-8' );
 		$document       = new DomDocument( '1.0', 'UTF-8' );
 
 		libxml_use_internal_errors( true );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
PHP >= 8.2 was getting deprecation notices for mb_convert_string

```
Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in /var/www/html/wp-content/plugins/headless-wp/includes/classes/Integrations/Gutenberg.php on line 192
```

`mb_convert_string` usage with `HTML-ENTITIES` has been deprecated.

### How to test the Change
Run the unit tests.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
