### PR TITLE
patch: fix epio search types

### DIFF
--- a/.changeset/dry-lamps-approve.md
+++ b/.changeset/dry-lamps-approve.md
@@ -1,0 +1,5 @@
+---
+"@10up/wp-nextjs-epio": patch
+---
+
+correctly export types

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup npm cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/nextjs_bundle_analysis-app-router.yml
+++ b/.github/workflows/nextjs_bundle_analysis-app-router.yml
@@ -27,7 +27,7 @@ jobs:
         run: (cd ../../ && npm ci)
 
       - name: Restore next build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: restore-build-cache
         env:
           cache-name: cache-next-build

--- a/packages/epio-search/README.md
+++ b/packages/epio-search/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-* Elasticsearch per [ElasticPress requirements](https://github.com/10up/ElasticPress#requirements).
+* ElasticPress per [ElasticPress requirements](https://github.com/10up/ElasticPress#requirements).
 * WordPress website running [ElasticPress](https://elasticpress.io).
 
 ## Installation

--- a/packages/epio-search/src/index.ts
+++ b/packages/epio-search/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components';
 export * from './utils';
 export * from './hooks';
+export * from './types';


### PR DESCRIPTION
### Description of the Change
Corrects an issue where the TypeScript types were not correctly exported from the EPIO Search package.

### How to test the Change
Try to `import { type EPPost } from '@headstartwp/epio-search';`

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
