### PR TITLE
fix: withHeadstartWPConfig rewrites need to account for app router path

### DIFF
--- a/.changeset/warm-fireants-remain.md
+++ b/.changeset/warm-fireants-remain.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/next": minor
+---
+
+support app router in withHeadstartWPConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -35131,7 +35131,7 @@
     },
     "test-projects/wp-nextjs-epio": {
       "name": "@10up/wp-nextjs-epio",
-      "version": "0.1.0",
+      "version": "0.1.1-next.0",
       "dependencies": {
         "@headstartwp/core": "^1.5.0-next.8",
         "@headstartwp/epio-search": "file:../epio-search",

--- a/packages/next/src/config/withHeadstartWPConfig.ts
+++ b/packages/next/src/config/withHeadstartWPConfig.ts
@@ -200,7 +200,7 @@ export function withHeadstartWPConfig(
 
 				let shouldRewriteYoastSEOUrls = topLevelShouldRewriteYoastSEOUrls;
 				if (site.integrations?.yoastSEO) {
-					shouldRewriteYoastSEOUrls = site.integrations.yoastSEO.enable === true ? 1 : 0;
+					shouldRewriteYoastSEOUrls = site.integrations.yoastSEO?.enable === true ? 1 : 0;
 				}
 
 				const defaultRewrites = [

--- a/packages/next/src/config/withHeadstartWPConfig.ts
+++ b/packages/next/src/config/withHeadstartWPConfig.ts
@@ -189,7 +189,12 @@ export function withHeadstartWPConfig(
 
 			sites.forEach((site) => {
 				const wpUrl = site.sourceUrl;
-				const prefix = isMultisite ? '/_sites/:site' : '';
+				let prefix = '';
+				if (isUsingAppRouter) {
+					prefix = isMultisite ? '/:site' : '';
+				} else {
+					prefix = isMultisite ? '/_sites/:site' : '';
+				}
 				const shouldRewriteYoastSEOUrls =
 					site.integrations?.yoastSEO?.enable === true ? 1 : 0;
 
@@ -207,7 +212,7 @@ export function withHeadstartWPConfig(
 						destination: `${wpUrl}/feed/?rewrite_urls=1`,
 					},
 					{
-						source: '/robots.txt',
+						source: `${prefix}/robots.txt`,
 						destination: `${wpUrl}/robots.txt?rewrite_urls=${shouldRewriteYoastSEOUrls}`,
 					},
 					// Yoast redirects sitemap.xml to sitemap_index.xml,

--- a/packages/next/src/config/withHeadstartWPConfig.ts
+++ b/packages/next/src/config/withHeadstartWPConfig.ts
@@ -186,6 +186,8 @@ export function withHeadstartWPConfig(
 		async rewrites() {
 			const rewrites =
 				typeof nextConfig.rewrites === 'function' ? await nextConfig.rewrites() : [];
+			const topLevelShouldRewriteYoastSEOUrls =
+				headlessConfig?.integrations?.yoastSEO?.enable === true ? 1 : 0;
 
 			sites.forEach((site) => {
 				const wpUrl = site.sourceUrl;
@@ -195,8 +197,11 @@ export function withHeadstartWPConfig(
 				} else {
 					prefix = isMultisite ? '/_sites/:site' : '';
 				}
-				const shouldRewriteYoastSEOUrls =
-					site.integrations?.yoastSEO?.enable === true ? 1 : 0;
+
+				let shouldRewriteYoastSEOUrls = topLevelShouldRewriteYoastSEOUrls;
+				if (site.integrations?.yoastSEO) {
+					shouldRewriteYoastSEOUrls = site.integrations.yoastSEO.enable === true ? 1 : 0;
+				}
 
 				const defaultRewrites = [
 					{

--- a/packages/next/src/config/withHeadstartWPConfig.ts
+++ b/packages/next/src/config/withHeadstartWPConfig.ts
@@ -1,4 +1,4 @@
-import { ConfigError, HeadlessConfig } from '@headstartwp/core';
+import { ConfigError, HeadlessConfig, getSite } from '@headstartwp/core';
 import { NextConfig } from 'next';
 import fs from 'fs';
 import { ModifySourcePlugin, ConcatOperation } from './plugins/ModifySourcePlugin';
@@ -186,22 +186,18 @@ export function withHeadstartWPConfig(
 		async rewrites() {
 			const rewrites =
 				typeof nextConfig.rewrites === 'function' ? await nextConfig.rewrites() : [];
-			const topLevelShouldRewriteYoastSEOUrls =
-				headlessConfig?.integrations?.yoastSEO?.enable === true ? 1 : 0;
 
-			sites.forEach((site) => {
+			sites.forEach((rawSite) => {
+				const site = getSite(rawSite);
 				const wpUrl = site.sourceUrl;
-				let prefix = '';
+
+				let prefix = isMultisite ? '/_sites/:site' : '';
 				if (isUsingAppRouter) {
 					prefix = isMultisite ? '/:site' : '';
-				} else {
-					prefix = isMultisite ? '/_sites/:site' : '';
 				}
 
-				let shouldRewriteYoastSEOUrls = topLevelShouldRewriteYoastSEOUrls;
-				if (site.integrations?.yoastSEO) {
-					shouldRewriteYoastSEOUrls = site.integrations.yoastSEO?.enable === true ? 1 : 0;
-				}
+				const shouldRewriteYoastSEOUrls =
+					site.integrations?.yoastSEO?.enable === true ? 1 : 0;
 
 				const defaultRewrites = [
 					{


### PR DESCRIPTION
### Description of the Change
`robots.txt` and `sitemap.xml` rewrites stopped working after migrating to multisite and app router. 

1. Found that the withHeadstartWPConfig rewrite logic didn't account for the app router prefix. 
2. Also found that the top-level Integration settings for YoastSEO weren't honored in multisite. 

### How to test the Change
1. In a multisite app using app router with `yoastSEO` enabled in the `integrations` object in headstartwp.config.js, test that the rewrite for `robots.txt` results in a 404 error. Same for `sitemap.xml`.
2. Apply this patch and test again. The rewrite rules should rewrite to the correct path.

### Changelog Entry
> Fixed - app router/multisite prefix logic in withHeadstartWPConfig
> Fixed - yoastSEO integration setting at top-level of headstart config in multisite mode

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
