### PR TITLE
fix: revalidateRouteHandler path for App Router

### DIFF
--- a/.changeset/cute-shoes-dance.md
+++ b/.changeset/cute-shoes-dance.md
@@ -1,0 +1,6 @@
+---
+"@headstartwp/next": patch
+---
+
+Fix: revalidate path
+Added: A new optional callback parameter was added to `revalidateRouteHandler`. This callback allows extra logic to be run after the path is revalidated. For instance, `revalidateTag` may need to be called for a specific query, or a redis tag may need to be deleted.

--- a/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
+++ b/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
@@ -7,24 +7,24 @@ import { getHostAndConfigFromRequest } from './utils';
  * Returns the path to revalidate
  *
  * @param path The path being revalidated
- * @param host The host for which the path is being revalidated
+ * @param slug The site slug for which the path is being revalidated
  * @param locale The locale for which the path is being revalidated
  * @param isMultisiteRequest Whether this is a multisite request
  * @returns
  */
 function getPathToRevalidate(
 	path: string,
-	host: string,
+	slug: string | undefined,
 	locale: string | null,
 	isMultisiteRequest: boolean,
 ) {
 	let pathToRevalidate = path;
 
-	if (isMultisiteRequest) {
+	if (isMultisiteRequest && slug) {
 		if (locale) {
-			pathToRevalidate = `/_sites/${host}/${locale}/${path}`;
+			pathToRevalidate = `/${locale}/${slug}/${path}`;
 		}
-		pathToRevalidate = `/_sites/${host}${path}`;
+		pathToRevalidate = `/${slug}/${path}`;
 	}
 
 	return pathToRevalidate;
@@ -71,8 +71,7 @@ export async function revalidateRouteHandler(request: NextRequest) {
 	}
 
 	const {
-		host,
-		config: { sourceUrl },
+		config: { sourceUrl, slug },
 		isMultisiteRequest,
 	} = getHostAndConfigFromRequest(request);
 
@@ -94,7 +93,7 @@ export async function revalidateRouteHandler(request: NextRequest) {
 
 		const pathToRevalidate = getPathToRevalidate(
 			verifiedPath,
-			host,
+			slug,
 			locale,
 			isMultisiteRequest,
 		);

--- a/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
+++ b/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
@@ -55,7 +55,10 @@ function getPathToRevalidate(
  *
  * @category Route handlers
  */
-export async function revalidateRouteHandler(request: NextRequest, callback) {
+export async function revalidateRouteHandler(
+	request: NextRequest,
+	callback: Function | null = null,
+) {
 	const { searchParams } = request.nextUrl;
 
 	const post_id = Number(searchParams.get('post_id') ?? 0);

--- a/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
+++ b/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
@@ -49,12 +49,13 @@ function getPathToRevalidate(
  * ```
  *
  * @param request The Next Request
+ * @param callback Optional callback function to be called after revalidation
  *
  * @returns A response object.
  *
  * @category Route handlers
  */
-export async function revalidateRouteHandler(request: NextRequest) {
+export async function revalidateRouteHandler(request: NextRequest, callback) {
 	const { searchParams } = request.nextUrl;
 
 	const post_id = Number(searchParams.get('post_id') ?? 0);
@@ -99,6 +100,11 @@ export async function revalidateRouteHandler(request: NextRequest) {
 		);
 
 		revalidatePath(pathToRevalidate);
+
+		// check if callback is set and a function before calling it
+		if (callback && typeof callback === 'function') {
+			await callback({ verifiedPath, slug, locale, isMultisiteRequest });
+		}
 
 		return new Response(JSON.stringify({ message: 'success', path: pathToRevalidate }), {
 			status: 200,

--- a/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
+++ b/packages/next/src/rsc/handlers/revalidateRouterHandler.ts
@@ -3,28 +3,32 @@ import { revalidatePath } from 'next/cache';
 import { NextRequest } from 'next/server';
 import { getHostAndConfigFromRequest } from './utils';
 
+interface RevalidateRouteHandlerArgs {
+	verifiedPath: string;
+	slug: string | undefined;
+	locale: string | null;
+	isMultisiteRequest: boolean;
+}
 /**
  * Returns the path to revalidate
  *
- * @param path The path being revalidated
- * @param slug The site slug for which the path is being revalidated
- * @param locale The locale for which the path is being revalidated
- * @param isMultisiteRequest Whether this is a multisite request
- * @returns
+ * @param args The arguments for revalidation
+ * @returns The path to revalidate
  */
-function getPathToRevalidate(
-	path: string,
-	slug: string | undefined,
-	locale: string | null,
-	isMultisiteRequest: boolean,
-) {
-	let pathToRevalidate = path;
+function getPathToRevalidate({
+	verifiedPath,
+	slug,
+	locale,
+	isMultisiteRequest,
+}: RevalidateRouteHandlerArgs): string {
+	let pathToRevalidate = verifiedPath;
 
 	if (isMultisiteRequest && slug) {
 		if (locale) {
-			pathToRevalidate = `/${locale}/${slug}/${path}`;
+			pathToRevalidate = `/${locale}/${slug}/${verifiedPath}`;
+		} else {
+			pathToRevalidate = `/${slug}/${verifiedPath}`;
 		}
-		pathToRevalidate = `/${slug}/${path}`;
 	}
 
 	return pathToRevalidate;
@@ -57,7 +61,7 @@ function getPathToRevalidate(
  */
 export async function revalidateRouteHandler(
 	request: NextRequest,
-	callback: Function | null = null,
+	callback: ((args: RevalidateRouteHandlerArgs) => Promise<void>) | null = null,
 ) {
 	const { searchParams } = request.nextUrl;
 
@@ -95,12 +99,12 @@ export async function revalidateRouteHandler(
 			throw new Error('Token mismatch');
 		}
 
-		const pathToRevalidate = getPathToRevalidate(
+		const pathToRevalidate = getPathToRevalidate({
 			verifiedPath,
 			slug,
 			locale,
 			isMultisiteRequest,
-		);
+		});
 
 		revalidatePath(pathToRevalidate);
 


### PR DESCRIPTION
The `revalidateRouteHandler` function uses the path pattern for the pages router: `/_sites/${host}${path}`. When `revalidatePath(pathToRevalidate)` is called, the `pathToRevalidate` is incorrect, resulting in WordPress content updates not  appearing on the frontend without a manual cache purge.

### How to test the Change
On a site with caching enabled, update a WordPress page. The updated content will not automatically appear on the frontend (when using App Router). The `/api/revalidate` endpoint is called, but the computed path to revalidate is incorrect. 

### Changelog Entry
> Changed - With this change, the correct path is created, resulting in a properly revalidated path.
> Added - A new optional callback parameter was added to `revalidateRouteHandler`. This callback allows extra logic to be run after the path is revalidated. For instance, revalidateTag may need to be called for a specific query, or a `redis` tag may need to be deleted.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
