### PR TITLE
fix: account for possible 'single' property in the default post types for post path matching

### DIFF
--- a/.changeset/free-rocks-take.md
+++ b/.changeset/free-rocks-take.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": patch
+---
+
+Fix: account for possible `single` property in the default post types when executing the default post path matching.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,8 @@ jobs:
   build-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      # This ensures only one combination runs at a time to avoid rate limiting
+      max-parallel: 1
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [18, 20, 22]
@@ -13,7 +15,7 @@ jobs:
           - os: windows-latest
             node-version: 18
           - os: windows-latest
-            node-version: 20
+            node-version: 20   
 
     steps:
       - name: Configure Git line endings

--- a/docs/documentation/01-Getting Started/headless-config.md
+++ b/docs/documentation/01-Getting Started/headless-config.md
@@ -111,6 +111,27 @@ module.exports = {
 }
 ```
 
+Another use case is if you want your posts to sit at a different prefix (e.g: `/blog`), you can change your permalinks in WordPress (e.g: `/blog/%postname/`) and update the default `post` post type so that its `sigle` property is equal to `/blog`.
+
+```js title="headstartwp.config.js"
+module.exports = {
+    sourceUrl: process.env.NEXT_PUBLIC_HEADLESS_WP_URL,
+    hostUrl: process.env.HOST_URL,
+    customPostTypes: (defaultPostTypes) => {
+		return defaultPostTypes.map((postType) => {
+			if (postType === 'post') {
+				return {
+					...postType,
+					single: '/blog'
+				}
+			}
+
+			return postType;
+		};
+	}
+}
+```
+
 ## customTaxonomies
 
 To add support for custom taxonomies, add your custom taxonomy to the `customTaxonomies` setting in `headstartwp.config.js`.

--- a/packages/core/src/data/strategies/SinglePostFetchStrategy.ts
+++ b/packages/core/src/data/strategies/SinglePostFetchStrategy.ts
@@ -191,7 +191,13 @@ export class SinglePostFetchStrategy<
 				}
 			}
 
-			return postPath === currentPath || postPath === `/${this.locale}${currentPath}`;
+			const postPostTypeObject = getCustomPostType('post', this.baseURL);
+			const postSinglePrefix = postPostTypeObject?.single?.replace(/\/?$/, '') ?? '';
+
+			return (
+				postPath === `${postSinglePrefix}${currentPath}` ||
+				postPath === `/${this.locale}${postSinglePrefix}${currentPath}`
+			);
 		});
 	}
 

--- a/packages/core/src/data/strategies/__tests__/SinglePostFetchStrategy.ts
+++ b/packages/core/src/data/strategies/__tests__/SinglePostFetchStrategy.ts
@@ -1,4 +1,4 @@
-import { setHeadlessConfig } from '../../../utils';
+import { getHeadstartWPConfig, setHeadlessConfig, setHeadstartWPConfig } from '../../../utils';
 import { apiGet } from '../../api';
 import { PostParams, SinglePostFetchStrategy } from '../SinglePostFetchStrategy';
 
@@ -439,20 +439,57 @@ describe('SinglePostFetchStrategy', () => {
 		});
 	});
 
-	it('handles post path mapping', async () => {
+	it.each([
+		{
+			settings: {
+				customPostTypes: [{ slug: 'post', single: '/', endpoint: '/wp-json/wp/v2/posts' }],
+			},
+			mockedData: [
+				{ title: 'test', id: 1, link: `http://sourceurl.com/%s` },
+				{
+					title: 'test',
+					id: 2,
+					link: `http://sourceurl.com/%s`,
+				},
+			],
+		},
+		{
+			settings: {
+				customPostTypes: [
+					{
+						slug: 'post',
+						single: '/blog',
+						archive: '/blog',
+						endpoint: '/wp-json/wp/v2/posts',
+					},
+				],
+			},
+			mockedData: [
+				{ title: 'test', id: 1, link: `http://sourceurl.com/blog/%s` },
+				{
+					title: 'test',
+					id: 2,
+					link: `http://sourceurl.com/blog/%s`,
+				},
+			],
+		},
+	])('handles post path mapping with and without prefix', async ({ settings, mockedData }) => {
 		const englishPostSlug = 'test';
 		const utf8EncodedPostSlug = 'لأخبار-المالية';
+		const originalSettings = getHeadstartWPConfig();
+
+		setHeadstartWPConfig({
+			...originalSettings,
+			...settings,
+		});
 
 		const post1 = {
-			title: 'test',
-			id: 1,
-			link: `http://sourceurl.com/${englishPostSlug}`,
+			...mockedData[0],
+			link: `${mockedData[0].link.replace('%s', englishPostSlug)}`,
 		};
-
 		const post2 = {
-			title: 'test',
-			id: 2,
-			link: `http://sourceurl.com/${encodeURIComponent(utf8EncodedPostSlug)}`,
+			...mockedData[1],
+			link: `${mockedData[1].link.replace('%s', encodeURIComponent(utf8EncodedPostSlug))}`,
 		};
 
 		apiGetMock.mockResolvedValue({


### PR DESCRIPTION

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #851 

This PR addresses a bug where the default `post` post type could not sit at a different level than root without disabling post path mapping.

### How to test the Change
1. Update permalinks settings to `/blog/%postname%/` in WordPress
2. Update your `customPostTypes` in `headstartwp.config.js` to 
```js
 customPostTypes: (defaultPostTypes) => {
      return defaultPostTypes.map((postType) => {
         if (postType.slug === 'post') {
            return { ...postType, single: '/blog', archive: '/blog' };
        }
       return postType;
      });
  };
```
3. Verify that `/blog` route loads both archive of posts and single posts.
4. Run the test on both the pages router app and App Router app.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
