### PR TITLE
chore: switch to google tag manager

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -32,9 +32,8 @@ const config = {
 			({
 				docs: false,
 				blog: false,
-				gtag: {
-					trackingID: 'G-WF1Z7JSCXS',
-					anonymizeIP: true,
+				googleTagManager: {
+					containerId: 'GTM-TKCGKK2',
 				},
 				theme: {
 					customCss: './src/css/custom.css',


### PR DESCRIPTION
Install Google Tag Manager