### PR TITLE
Support strict-psr

### DIFF
--- a/.changeset/huge-hornets-tan.md
+++ b/.changeset/huge-hornets-tan.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/headstartwp": patch
+---
+
+Make headstartwp PSR-4 compliant: add autoload.psr-4 mapping for php-jwt, remove require_once of php-jwt files

--- a/wp/headless-wp/composer.json
+++ b/wp/headless-wp/composer.json
@@ -45,7 +45,8 @@
   },
   "autoload": {
     "psr-4": {
-      "HeadlessWP\\": "includes/classes/"
+      "HeadlessWP\\": "includes/classes/",
+      "HeadlessWP\\JWT\\": "includes/classes/php-jwt/"
     }
   },
   "scripts": {

--- a/wp/headless-wp/plugin.php
+++ b/wp/headless-wp/plugin.php
@@ -22,39 +22,29 @@ define( 'HEADLESS_WP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'HEADLESS_WP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'HEADLESS_WP_PLUGIN_INC', HEADLESS_WP_PLUGIN_PATH . 'includes/' );
 
-// Load php-jwt classes.
-$jwt_files = [
-	'BeforeValidException.php',
-	'ExpiredException.php',
-	'JWK.php',
-	'JWT.php',
-	'SignatureInvalidException.php',
-];
-
-foreach ( $jwt_files as $filename ) {
-	require_once HEADLESS_WP_PLUGIN_PATH . '/includes/classes/php-jwt/' . $filename;
-}
-
 // Require Composer autoloader if it exists.
 if ( file_exists( HEADLESS_WP_PLUGIN_PATH . '/vendor/autoload.php' ) ) {
 	require_once HEADLESS_WP_PLUGIN_PATH . 'vendor/autoload.php';
 } else {
+	// PSR-4 map (longest/more-specific prefixes should come first)
+	$psr4 = [
+		'HeadlessWP\\JWT\\' => __DIR__ . '/includes/classes/php-jwt/',
+		'HeadlessWP\\'      => __DIR__ . '/includes/classes/',
+	];
 	spl_autoload_register(
-		function ( $the_class ) {
-				// Project-specific namespace prefix.
-				$prefix = 'HeadlessWP\\';
-				// Base directory for the namespace prefix.
-				$base_dir = __DIR__ . '/includes/classes/';
-				// Does the class use the namespace prefix?
+		function ( $the_class ) use ( $psr4 ) {
+			foreach ( $psr4 as $prefix => $base_dir ) {
 				$len = strlen( $prefix );
-			if ( strncmp( $prefix, $the_class, $len ) !== 0 ) {
-				return;
-			}
+				if ( strncmp( $prefix, $the_class, $len ) !== 0 ) {
+					continue;
+				}
 				$relative_class = substr( $the_class, $len );
 				$file           = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
 				// If the file exists, require it.
-			if ( file_exists( $file ) ) {
-				require $file;
+				if ( file_exists( $file ) ) {
+					require $file;
+					return;
+				}
 			}
 		}
 	);


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Add PSR-4 mapping for php-jwt to fix error running `composer dump-autoload --optimize --classmap-authoritative --strict-psr --strict-ambiguous`. I wish to add `--classmap-authoritative` to my wordpress app for performance reasons (in particular, so I can also enable `ClassFinder::disablePSR4Vendors();` in [ClassFinder](https://gitlab.com/hpierce1102/ClassFinder)) but the headstartwp mu-plugin is preventing me from being able to use `--classmap-authoritative` safely.

Remove `require_once` for php-jwt which appeared to be a workaround for the missing PSR-4 mapping.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR.
Closes #
-->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Run this command and make sure it runs without error:

```
composer dump-autoload --optimize --classmap-authoritative --strict-psr --strict-ambiguous --working-dir=./
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. 
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
> Developer - Non-functional update
-->
> Developer - Make headless-wp PSR-4 compliant: add autoload.psr-4 mapping for php-jwt, remove require_once of php-jwt files


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
