### PR TITLE
docs(example): add Next.js blog example page with usePosts hook

### DIFF
--- a/test-projects/next/pages/blog.tsx
+++ b/test-projects/next/pages/blog.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { usePosts } from "@headstartwp/next"; // hook from headstartwp
+
+export default function BlogPage() {
+  const { data, isLoading, error } = usePosts({
+    perPage: 5,
+  });
+
+  if (isLoading) return <p>Loading posts...</p>;
+  if (error) return <p>Failed to load posts.</p>;
+
+  return (
+    <main style={{ padding: "2rem", fontFamily: "sans-serif" }}>
+      <h1>Latest Blog Posts</h1>
+      {data?.posts?.length ? (
+        <ul>
+          {data.posts.map((post) => (
+            <li key={post.id}>
+              <a href={post.link} target="_blank" rel="noopener noreferrer">
+                {post.title.rendered}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No posts found.</p>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
This PR adds a new example page under test-projects/next/pages/blog.tsx that demonstrates how to fetch and render blog posts from WordPress using the usePosts hook.

Fetches 5 latest posts

Displays loading and error states

Provides a minimal Next.js integration example

This helps new developers quickly understand how to connect WordPress content with a Next.js frontend.