### PR TITLE
fix: add check for taxonomy rewrite array in Links class

### DIFF
--- a/wp/headless-wp/includes/classes/Links.php
+++ b/wp/headless-wp/includes/classes/Links.php
@@ -64,6 +64,11 @@ class Links {
 					continue;
 				}
 
+				// Skip if rewrite is not an array (could be false or not set)
+				if ( ! is_array( $taxonomy->rewrite ) || empty( $taxonomy->rewrite['slug'] ) ) {
+					continue;
+				}
+
 				$rewrite_slug      = $taxonomy->rewrite['slug'];
 				$rewrite_query_var = $taxonomy->query_var;
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

When accessing the /wp-admin/ there is a PHP error that can appear:

`Warning: Trying to access array offset on value of type bool in /var/www/html/wp-content/plugins/headstartwp/includes/classes/Links.php on line 67`

The error occurs because:

1. `get_object_taxonomies( $post_type, 'object' )` returns taxonomy objects
2. Some taxonomies have `$taxonomy->rewrite` set to `false` instead of an array
3. The original code attempted to access `$taxonomy->rewrite['slug']` without checking if `rewrite` is an array
4. PHP 7.4+ throws a warning when accessing array offset on boolean `false`

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. **Clear rewrite rules**: `delete_option( 'rewrite_rules' )`
2. **Access `/wp-admin`**: Should regenerate rules without errors
3. **Check error logs**: No PHP warnings should appear
4. **Verify rewrite rules**: Check that valid taxonomies still have rules generated
5. **Test with problematic taxonomy**: Register taxonomy with `rewrite => false` and `show_in_rest => true`, verify no errors

- [ ] Create taxonomy with `rewrite => false` and `show_in_rest => true`
- [ ] Access `/wp-admin` after clearing rewrite rules
- [ ] Manually flush rewrite rules via Settings → Permalinks
- [ ] Activate/deactivate plugins that register taxonomies
- [ ] Test with multiple post types and taxonomies
- [ ] Verify no PHP warnings in error logs
- [ ] Verify rewrite rules are generated correctly


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - error when taxonomy rewrite is not an array

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @michael-sumner 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [X] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [X] All new and existing tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a check to skip taxonomies with non-array or missing `rewrite['slug']` when building rewrite rules to avoid PHP warnings.
> 
> - **Links** (`wp/headless-wp/includes/classes/Links.php`):
>   - In `create_taxonomy_rewrites`, skip taxonomies when `rewrite` is not an array or `rewrite['slug']` is empty, preventing access of array offsets on non-arrays and limiting rule generation to valid taxonomies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82cf7d602374cb504f6dc465e8da5f18e8a4306a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->