### PR TITLE
fix: shouldSkipRedirect incorrectly skips cross-domain redirects

### DIFF
--- a/.changeset/fix-cross-domain-redirect-skip.md
+++ b/.changeset/fix-cross-domain-redirect-skip.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/core": patch
+---
+
+Fix: shouldSkipRedirect incorrectly skipping cross-domain redirects when pathnames match. Fixes #941

--- a/packages/core/src/utils/__tests__/fetchRedirect.ts
+++ b/packages/core/src/utils/__tests__/fetchRedirect.ts
@@ -51,4 +51,18 @@ describe('fetchRedirect', () => {
 
 		global.fetch = originalFetch;
 	});
+
+	it('handles cross-domain redirect with same pathname', async () => {
+		const result = await fetchRedirect('/recipe/my-recipe/', 'http://example.com/');
+
+		expect(result.location).toBe('https://www.external-domain.com/recipe/my-recipe/');
+		expect(result.status).toBe(302);
+	});
+
+	it('handles cross-domain redirect with different pathname', async () => {
+		const result = await fetchRedirect('/old-recipe/', 'http://example.com/');
+
+		expect(result.location).toBe('https://www.external-domain.com/new-recipe/');
+		expect(result.status).toBe(301);
+	});
 });

--- a/packages/core/src/utils/fetchRedirect.ts
+++ b/packages/core/src/utils/fetchRedirect.ts
@@ -28,6 +28,11 @@ function shouldSkipRedirect(link: string, redirect: string, sourceUrl: string) {
 		return true;
 	}
 
+	// Cross-domain redirects should never be skipped
+	if (linkURL.host !== redirectURL.host) {
+		return false;
+	}
+
 	const linkParams = linkURL.searchParams;
 	const redirectParams = redirectURL.searchParams;
 

--- a/packages/core/test/server-handlers.ts
+++ b/packages/core/test/server-handlers.ts
@@ -36,6 +36,16 @@ const handlers = [
 		return res(redirect('http://example.com/redirect-test-missing-slash', 301));
 	}),
 
+	// Cross-domain redirect with same pathname
+	rest.head('http://example.com/recipe/my-recipe/', (req, res) => {
+		return res(redirect('https://www.external-domain.com/recipe/my-recipe/', 302));
+	}),
+
+	// Cross-domain redirect with different pathname
+	rest.head('http://example.com/old-recipe/', (req, res) => {
+		return res(redirect('https://www.external-domain.com/new-recipe/', 301));
+	}),
+
 	rest.get<DefaultRequestBody, TestEndpointResponse>(/\/test-endpoint/, (req, res, ctx) => {
 		return res(ctx.json({ ok: true }));
 	}),


### PR DESCRIPTION
## Summary

- Adds host comparison check in `shouldSkipRedirect` to ensure cross-domain redirects are never skipped
- Fixes an issue where redirects configured from one domain to another with the same pathname would result in 404 errors instead of proper redirects

Fixes #941

## Changes

**`packages/core/src/utils/fetchRedirect.ts`:**
- Added early return in `shouldSkipRedirect` when `linkURL.host !== redirectURL.host`
- Cross-domain redirects now bypass the pathname comparison logic and are properly followed

## Test plan

- [x] Added test for cross-domain redirect with same pathname
- [x] Added test for cross-domain redirect with different pathname
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to redirect-skipping logic with added test coverage; limited to redirect resolution behavior.
> 
> **Overview**
> Fixes `fetchRedirect` incorrectly treating cross-domain redirects as skippable when the pathname/query matches, by adding a host comparison so cross-domain redirects are always followed.
> 
> Adds MSW handlers and unit tests covering cross-domain redirects with both identical and different pathnames, and includes a patch changeset for `@headstartwp/core`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b05c4d7a01ea6cd743f2266e696ba89839dbb21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->