### PR TITLE
fix: undefined array key 'context' warning in Gutenberg.php (PHP 8+)

### DIFF
--- a/.changeset/fix-undefined-context-key.md
+++ b/.changeset/fix-undefined-context-key.md
@@ -1,0 +1,5 @@
+---
+"@headstartwp/headstartwp": patch
+---
+
+Fix: Add null coalescing check for context parameter in extend_post_content to prevent PHP 8+ "Undefined array key" warning. Fixes #940

--- a/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
+++ b/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
@@ -87,7 +87,7 @@ class Gutenberg {
 
 		$params = $request->get_params();
 
-		if ( 'view' !== $params['context'] ) {
+		if ( 'view' !== ( $params['context'] ?? '' ) ) {
 			return $data;
 		}
 


### PR DESCRIPTION
## Summary

- Adds null coalescing check for `context` parameter in `extend_post_content` method
- Prevents PHP 8+ "Undefined array key" warnings that corrupt JSON responses

Fixes #940

## Problem

The `extend_post_content` method in `Gutenberg.php` accesses `$params['context']` without checking if the key exists. In PHP 8.0+, this triggers an "Undefined array key" warning when the `context` query parameter is not explicitly provided in the REST API request.

This warning is output before the JSON response, corrupting the response body:
```
<br />
<b>Warning</b>: Undefined array key "context" in <b>.../Gutenberg.php</b> on line <b>90</b><br />
[{"id":123,...}]
```

## Solution

Use the null coalescing operator to default to an empty string when `context` key doesn't exist:

```php
// Before
if ( 'view' !== $params['context'] ) {

// After  
if ( 'view' !== ( $params['context'] ?? '' ) ) {
```

## Test plan

- [ ] Make REST API request without context parameter: `GET /wp-json/wp/v2/pages?slug=test`
- [ ] Verify response is clean JSON without PHP warnings
- [ ] Make REST API request with context parameter: `GET /wp-json/wp/v2/pages?slug=test&context=view`
- [ ] Verify block_styles are still added to response when context=view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive check change plus a changeset; behavior only differs when `context` is missing, reducing warnings without affecting normal `context=view` requests.
> 
> **Overview**
> Prevents PHP 8+ "Undefined array key" warnings (and potential JSON response corruption) when `extend_post_content` runs on REST requests that omit the `context` parameter by defaulting `$params['context']` to an empty string.
> 
> Adds a patch changeset documenting the fix for `@headstartwp/headstartwp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c33e94b6d85d58d9ee4e82c1845ad397961d02ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->