### PR TITLE
Fix/workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,8 @@
 name: Build Test
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,8 @@
 name: Deploy to GitHub Pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/.github/workflows/deploy_wp_plugin_develop.yml
+++ b/.github/workflows/deploy_wp_plugin_develop.yml
@@ -2,6 +2,8 @@
 # this is disabled for now to avoid breaking projects using the older method of installation
 
 name: Release develop WP Plugin
+permissions:
+  contents: write
 
 on:
   push:

--- a/.github/workflows/deploy_wp_plugin_develop.yml
+++ b/.github/workflows/deploy_wp_plugin_develop.yml
@@ -2,6 +2,7 @@
 # this is disabled for now to avoid breaking projects using the older method of installation
 
 name: Release develop WP Plugin
+
 permissions:
   contents: write
 

--- a/.github/workflows/deploy_wp_plugin_stable.yml
+++ b/.github/workflows/deploy_wp_plugin_stable.yml
@@ -2,6 +2,9 @@ name: Release Stable WP Plugin
 
 ### This has been merged into release-latest-version action
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,5 +1,8 @@
 name: eslint
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/nextjs_bundle_analysis-app-router.yml
+++ b/.github/workflows/nextjs_bundle_analysis-app-router.yml
@@ -1,5 +1,9 @@
 name: '(App Router) Next.js Bundle Analysis'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
   push:

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -1,5 +1,11 @@
 name: '(Pages Router) Next.js Bundle Analysis'
 
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  issues: write
+
 on:
   pull_request:
   push:

--- a/.github/workflows/npm-release-next-version.yml
+++ b/.github/workflows/npm-release-next-version.yml
@@ -1,5 +1,9 @@
 name: Release @next
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,5 +1,8 @@
 name: PHPCS check
 
+permissions:
+  contents: read
+
 on: pull_request
 
 jobs:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,8 @@
 name: PHPUnit tests
 
+permissions:
+  contents: read
+
 on: pull_request
 
 jobs:

--- a/.github/workflows/release-latest-version.yml
+++ b/.github/workflows/release-latest-version.yml
@@ -1,5 +1,9 @@
 name: Release @latest
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: unit tests
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates the permissions configuration for several GitHub Actions workflows to explicitly declare the minimum required permissions for each workflow. This improves security by restricting token access to only what is needed for each workflow to run.

**Permissions configuration updates:**

* Build and test workflows now explicitly request read-only access to repository contents in `.github/workflows/build-test.yml`, `.github/workflows/eslint.yml`, `.github/workflows/phpcs.yml`, `.github/workflows/phpunit.yml`, and `.github/workflows/unit-tests.yml`. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R3-R5) [[2]](diffhunk://#diff-8deb4e00ff9e68f9e5e25914b8d329a413bfbc90ab5f8c97662324cc68903d2fR3-R5) [[3]](diffhunk://#diff-f621c7ec73ae73c758a64d5f030f2062fc73f50676d953035650636c052aac3fR3-R5) [[4]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510R3-R5) [[5]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R3-R5)

* Next.js bundle analysis workflows now request read access to contents, actions, and write access to pull requests and issues in `.github/workflows/nextjs_bundle_analysis.yml`, and read access to contents plus write access to pull requests in `.github/workflows/nextjs_bundle_analysis-app-router.yml`. [[1]](diffhunk://#diff-8e0a7a766ad2cd76e466f888588b429cc3ec2e7459922f23ba3318cdbbb717ccR3-R8) [[2]](diffhunk://#diff-961d6d47fa79510b59cd9e0a834b2c3ca9801275b0966575975c8f7da2123c1fR3-R6)

**Deployment and release workflows:**

* Documentation and plugin release workflows now request write access to repository contents in `.github/workflows/deploy-docs.yml`, `.github/workflows/deploy_wp_plugin_develop.yml`, and `.github/workflows/deploy_wp_plugin_stable.yml`. [[1]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R3-R5) [[2]](diffhunk://#diff-3d99b2488c93390ca86cc977b694f9cc74dcf65f7831647de98a2c89fb1482a0R6-R8) [[3]](diffhunk://#diff-0240fd10c70c8e4f3f41205fca6000d9c94375d3261704421e293dfdd88d9a90R5-R7)

* NPM and latest release workflows now request write access to contents and pull requests in `.github/workflows/npm-release-next-version.yml` and `.github/workflows/release-latest-version.yml`. [[1]](diffhunk://#diff-5536fddf891f68eb3fdc10b71c35df9377033bb2ba1abd34d18820bc8546d02bR3-R6) [[2]](diffhunk://#diff-49c17d1b9a3868bc6d7d9d28d87c9a899ae29a0bb60c3f0e6eed8f6dc9bff4d9R3-R6)

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission scoping change; low functional risk, with the main risk being CI/deploy jobs failing if any required permission was missed.
> 
> **Overview**
> Adds explicit `permissions` blocks across GitHub Actions workflows to follow least-privilege defaults.
> 
> CI/test workflows are restricted to `contents: read`, while release/deploy workflows grant `contents: write` (and where needed `pull-requests: write`, plus `actions: read`/`issues: write` for bundle analysis) so they can publish artifacts and comment/update PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6db02429a503f6e5695047fdc5dce155c292ce17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>6db0242</u></sup><!-- /BUGBOT_STATUS -->