### PR TITLE
fix: allow dollar sign in custom blocks

### DIFF
--- a/.changeset/fix-gutenberg-dollar-sign.md
+++ b/.changeset/fix-gutenberg-dollar-sign.md
@@ -1,0 +1,6 @@
+---
+"@headstartwp/headstartwp": patch
+---
+
+Fix Gutenberg block attribute rendering when JSON attribute values contain dollar signs (for example, `$50 million`), preventing incorrect replacement escaping.
+

--- a/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
+++ b/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
@@ -320,7 +320,8 @@ class Gutenberg {
 	public function set_block_attributes_tag_api( $placeholder, $html, $block_attrs_serialized ) {
 		$search  = sprintf( '/data-wp-block="%s"/', preg_quote( $placeholder, '/' ) );
 		$replace = sprintf( 'data-wp-block="%s"', htmlspecialchars( $block_attrs_serialized ) );
-
+		// Escape backslashes and dollar signs for the replacement string
+		$replace = str_replace( array( '\\', '$' ), array( '\\\\', '\\$' ), $replace );
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return preg_replace(
 			$search,

--- a/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
+++ b/wp/headless-wp/includes/classes/Integrations/Gutenberg.php
@@ -321,7 +321,7 @@ class Gutenberg {
 		$search  = sprintf( '/data-wp-block="%s"/', preg_quote( $placeholder, '/' ) );
 		$replace = sprintf( 'data-wp-block="%s"', htmlspecialchars( $block_attrs_serialized ) );
 		// Escape backslashes and dollar signs for the replacement string
-		$replace = str_replace( array( '\\', '$' ), array( '\\\\', '\\$' ), $replace );
+		$replace = str_replace( [ '\\', '$' ], [ '\\\\', '\\$' ], $replace );
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return preg_replace(
 			$search,

--- a/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
+++ b/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
@@ -173,7 +173,9 @@ RESULT;
 
 		$enhanced = $this->parser->set_block_attributes_tag_api( $placeholder, $html, $attrs_json );
 
-		$this->assertStringContainsString( 'data-wp-block-name="', $enhanced, 'Sanity check: block-name attribute should exist.' );
+		// set_block_attributes_tag_api() only replaces the `data-wp-block` placeholder value.
+		$this->assertStringNotContainsString( $placeholder, $enhanced );
+		$this->assertStringContainsString( 'data-wp-block="', $enhanced );
 		// The core assertion: `$50` should not be interpreted by preg_replace() replacement parsing.
 		$this->assertStringContainsString( '$50 million', $enhanced );
 	}

--- a/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
+++ b/wp/headless-wp/tests/php/tests/TestGutenbergIntegration.php
@@ -153,6 +153,32 @@ RESULT;
 	}
 
 	/**
+	 * Tests HTML_Tag_Processor attribute injection does not drop `$...` sequences
+	 * in serialized JSON string values (e.g. "$50 million").
+	 *
+	 * This specifically covers the preg_replace() replacement-string escaping logic
+	 * used by set_block_attributes_tag_api().
+	 *
+	 * @return void
+	 */
+	public function test_set_block_attributes_tag_api_preserves_dollar_signs() {
+		$placeholder = '___HEADSTARTWP_BLOCK_ATTRS___';
+		$html         = '<p data-wp-block="' . $placeholder . '"></p>';
+		$attrs_json   = wp_json_encode(
+			[
+				'content' => '$50 million',
+				'level'   => 2,
+			]
+		);
+
+		$enhanced = $this->parser->set_block_attributes_tag_api( $placeholder, $html, $attrs_json );
+
+		$this->assertStringContainsString( 'data-wp-block-name="', $enhanced, 'Sanity check: block-name attribute should exist.' );
+		// The core assertion: `$50` should not be interpreted by preg_replace() replacement parsing.
+		$this->assertStringContainsString( '$50 million', $enhanced );
+	}
+
+	/**
 	 * Test to ensure the parser handles both HTML and Multi-byte encodings properly
 	 *
 	 * @return void
@@ -434,6 +460,14 @@ RESULT;
 					'level' => 2,
 				],
 				'<!-- wp:heading {"x":"&#038;"} --> <h2></h2> <!-- /wp:heading -->',
+			],
+			'block value containing dollar sign in JSON string' => [
+				'core/heading',
+				[
+					'x'     => '$50 million',
+					'level' => 2,
+				],
+				'<!-- wp:heading {"x":"$50 million"} --> <h2></h2> <!-- /wp:heading -->',
 			],
 			'html_entities'                                => [
 				'core/heading',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Client would like to be able to use dollar signs as text within custom blocks. Currently because of preg_replace() dollar signs and the immediate following text are being stripped and convert to empty strings.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Create a custom block that allows a user to provide string output via a text input or text area. Use a dollar sign in those fields and it should output example: $50

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Existing functionality

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @pdavies88 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [X] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [X] All new and existing tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted escaping change to a `preg_replace` replacement string, covered by new regression tests.
> 
> **Overview**
> Fixes a Gutenberg rendering edge case where `$...` sequences inside serialized JSON block attributes were being treated as `preg_replace()` replacement tokens and removed during `data-wp-block` injection.
> 
> `set_block_attributes_tag_api()` now escapes backslashes and dollar signs in the replacement string, and tests add coverage for dollar-sign values (including a new block roundtrip case) plus a changeset entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dc499b87cbec5857d44e99a03a233ec7f312153. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->